### PR TITLE
Tenant Enfrocement

### DIFF
--- a/src/common/models/error_metadata.py
+++ b/src/common/models/error_metadata.py
@@ -35,6 +35,7 @@ class ErrorCategory(str, Enum):
     TOOL_VERSION_INVALID = "tool_version_invalid"
     TOOL_VERSION_UNSUPPORTED = "tool_version_unsupported"
     TOOL_RESPONSE_MALFORMED = "tool_response_malformed"
+    TENANT_ENFORCEMENT_UNSUPPORTED = "TENANT_ENFORCEMENT_UNSUPPORTED"
 
 
 class ToolError(BaseModel):

--- a/src/dal/athena/executor.py
+++ b/src/dal/athena/executor.py
@@ -33,9 +33,11 @@ class AthenaAsyncQueryExecutor(AsyncQueryExecutor):
 
     async def submit(self, sql: str, params: Optional[list] = None) -> str:
         """Submit a query for asynchronous execution."""
-        from dal.util.read_only import enforce_read_only_sql
+        from dal.util.read_only import enforce_read_only_sql, validate_no_mutation_keywords
 
         enforce_read_only_sql(sql, provider="athena", read_only=self._read_only)
+        if self._read_only:
+            validate_no_mutation_keywords(sql)
         return await trace_query_operation(
             "dal.query.submit",
             provider="athena",

--- a/src/dal/athena/query_target.py
+++ b/src/dal/athena/query_target.py
@@ -14,6 +14,7 @@ from dal.tracing import trace_query_operation
 class AthenaQueryTargetDatabase:
     """Athena query-target database wrapper."""
 
+    supports_tenant_enforcement: bool = False
     _config: Optional[AthenaConfig] = None
 
     @classmethod

--- a/src/dal/bigquery/executor.py
+++ b/src/dal/bigquery/executor.py
@@ -31,9 +31,11 @@ class BigQueryAsyncQueryExecutor(AsyncQueryExecutor):
         """Submit a query for asynchronous execution."""
         from google.cloud import bigquery
 
-        from dal.util.read_only import enforce_read_only_sql
+        from dal.util.read_only import enforce_read_only_sql, validate_no_mutation_keywords
 
         enforce_read_only_sql(sql, provider="bigquery", read_only=self._read_only)
+        if self._read_only:
+            validate_no_mutation_keywords(sql)
         job_config = bigquery.QueryJobConfig()
         if params:
             job_config.query_parameters = params

--- a/src/dal/bigquery/query_target.py
+++ b/src/dal/bigquery/query_target.py
@@ -15,6 +15,7 @@ from dal.util.read_only import enforce_read_only_sql
 class BigQueryQueryTargetDatabase:
     """BigQuery query-target database wrapper."""
 
+    supports_tenant_enforcement: bool = False
     _config: Optional[BigQueryConfig] = None
 
     @classmethod

--- a/src/dal/database.py
+++ b/src/dal/database.py
@@ -26,6 +26,7 @@ class Database:
     _query_target_provider: str = "postgres"
     _query_target_capabilities = None
     _query_target_sync_max_rows: int = 0
+    supports_tenant_enforcement: bool = True
 
     @classmethod
     async def init(cls):
@@ -572,6 +573,54 @@ class Database:
     def get_query_target_provider(cls) -> str:
         """Return the active query-target provider."""
         return cls._query_target_provider
+
+    @classmethod
+    def supports_tenant_scope_enforcement(cls) -> bool:
+        """Return whether the active query-target enforces tenant isolation."""
+        provider = cls.get_query_target_provider().lower()
+        if provider == "postgres":
+            return bool(getattr(cls, "supports_tenant_enforcement", True))
+        if provider == "sqlite":
+            from dal.sqlite import SqliteQueryTargetDatabase
+
+            return bool(getattr(SqliteQueryTargetDatabase, "supports_tenant_enforcement", False))
+        if provider == "mysql":
+            from dal.mysql import MysqlQueryTargetDatabase
+
+            return bool(getattr(MysqlQueryTargetDatabase, "supports_tenant_enforcement", False))
+        if provider == "snowflake":
+            from dal.snowflake import SnowflakeQueryTargetDatabase
+
+            return bool(getattr(SnowflakeQueryTargetDatabase, "supports_tenant_enforcement", False))
+        if provider == "redshift":
+            from dal.redshift import RedshiftQueryTargetDatabase
+
+            return bool(getattr(RedshiftQueryTargetDatabase, "supports_tenant_enforcement", False))
+        if provider == "bigquery":
+            from dal.bigquery import BigQueryQueryTargetDatabase
+
+            return bool(getattr(BigQueryQueryTargetDatabase, "supports_tenant_enforcement", False))
+        if provider == "athena":
+            from dal.athena import AthenaQueryTargetDatabase
+
+            return bool(getattr(AthenaQueryTargetDatabase, "supports_tenant_enforcement", False))
+        if provider == "databricks":
+            from dal.databricks import DatabricksQueryTargetDatabase
+
+            return bool(
+                getattr(DatabricksQueryTargetDatabase, "supports_tenant_enforcement", False)
+            )
+        if provider == "duckdb":
+            from dal.duckdb import DuckDBQueryTargetDatabase
+
+            return bool(getattr(DuckDBQueryTargetDatabase, "supports_tenant_enforcement", False))
+        if provider == "clickhouse":
+            from dal.clickhouse import ClickHouseQueryTargetDatabase
+
+            return bool(
+                getattr(ClickHouseQueryTargetDatabase, "supports_tenant_enforcement", False)
+            )
+        return False
 
     @classmethod
     def get_query_target_capabilities(cls):

--- a/src/dal/databricks/executor.py
+++ b/src/dal/databricks/executor.py
@@ -35,9 +35,11 @@ class DatabricksAsyncQueryExecutor(AsyncQueryExecutor):
 
     async def submit(self, sql: str, params: Optional[list] = None) -> str:
         """Submit a query for asynchronous execution."""
-        from dal.util.read_only import enforce_read_only_sql
+        from dal.util.read_only import enforce_read_only_sql, validate_no_mutation_keywords
 
         enforce_read_only_sql(sql, provider="databricks", read_only=self._read_only)
+        if self._read_only:
+            validate_no_mutation_keywords(sql)
         payload = {
             "statement": sql,
             "warehouse_id": self._warehouse_id,

--- a/src/dal/databricks/query_target.py
+++ b/src/dal/databricks/query_target.py
@@ -14,6 +14,7 @@ from dal.tracing import trace_query_operation
 class DatabricksQueryTargetDatabase:
     """Databricks SQL Warehouse query-target wrapper."""
 
+    supports_tenant_enforcement: bool = False
     _config: Optional[DatabricksConfig] = None
 
     @classmethod

--- a/src/dal/feature_flags.py
+++ b/src/dal/feature_flags.py
@@ -4,3 +4,8 @@ from common.config.env import get_env_bool
 def experimental_features_enabled() -> bool:
     """Return True when experimental DAL features are enabled."""
     return get_env_bool("DAL_EXPERIMENTAL_FEATURES", False)
+
+
+def allow_non_postgres_tenant_bypass() -> bool:
+    """Return True when legacy non-Postgres tenant bypass is explicitly enabled."""
+    return bool(get_env_bool("ALLOW_NON_POSTGRES_TENANT_BYPASS", False))

--- a/src/dal/mysql/query_target.py
+++ b/src/dal/mysql/query_target.py
@@ -6,13 +6,14 @@ import aiomysql
 from dal.mysql.param_translation import translate_postgres_params_to_mysql
 from dal.mysql.quoting import translate_double_quotes_to_backticks
 from dal.tracing import trace_query_operation
-from dal.util.read_only import enforce_read_only_sql
+from dal.util.read_only import enforce_read_only_sql, validate_no_mutation_keywords
 from dal.util.row_limits import cap_rows_with_metadata, get_sync_max_rows
 
 
 class MysqlQueryTargetDatabase:
     """MySQL query-target database using aiomysql."""
 
+    supports_tenant_enforcement: bool = False
     _host: Optional[str] = None
     _port: int = 3306
     _db_name: Optional[str] = None
@@ -114,6 +115,8 @@ class _MysqlConnection:
         enforce_read_only_sql(sql, "mysql", self._read_only)
         sql = translate_double_quotes_to_backticks(sql)
         sql, bound_params = translate_postgres_params_to_mysql(sql, list(params))
+        if self._read_only:
+            validate_no_mutation_keywords(sql)
 
         async def _run():
             async with self._conn.cursor() as cursor:
@@ -132,6 +135,8 @@ class _MysqlConnection:
         enforce_read_only_sql(sql, "mysql", self._read_only)
         sql = translate_double_quotes_to_backticks(sql)
         sql, bound_params = translate_postgres_params_to_mysql(sql, list(params))
+        if self._read_only:
+            validate_no_mutation_keywords(sql)
 
         async def _run():
             async with self._conn.cursor() as cursor:
@@ -155,6 +160,8 @@ class _MysqlConnection:
         enforce_read_only_sql(sql, "mysql", self._read_only)
         sql = translate_double_quotes_to_backticks(sql)
         sql, bound_params = translate_postgres_params_to_mysql(sql, list(params))
+        if self._read_only:
+            validate_no_mutation_keywords(sql)
 
         async def _run():
             from dal.util.column_metadata import columns_from_cursor_description
@@ -180,6 +187,8 @@ class _MysqlConnection:
         enforce_read_only_sql(sql, "mysql", self._read_only)
         sql = translate_double_quotes_to_backticks(sql)
         sql, bound_params = translate_postgres_params_to_mysql(sql, list(params))
+        if self._read_only:
+            validate_no_mutation_keywords(sql)
 
         async def _run():
             async with self._conn.cursor() as cursor:

--- a/src/dal/snowflake/executor.py
+++ b/src/dal/snowflake/executor.py
@@ -21,9 +21,11 @@ class SnowflakeAsyncQueryExecutor(AsyncQueryExecutor):
 
     async def submit(self, sql: str, params: Optional[dict[str, Any] | List[Any]] = None) -> str:
         """Submit a query for asynchronous execution."""
-        from dal.util.read_only import enforce_read_only_sql
+        from dal.util.read_only import enforce_read_only_sql, validate_no_mutation_keywords
 
         enforce_read_only_sql(sql, provider="snowflake", read_only=self._read_only)
+        if self._read_only:
+            validate_no_mutation_keywords(sql)
         bound_params = params if params is not None else []
         return await trace_query_operation(
             "dal.query.submit",

--- a/tests/unit/dal/test_non_postgres_readonly_guard.py
+++ b/tests/unit/dal/test_non_postgres_readonly_guard.py
@@ -1,0 +1,41 @@
+"""Unit tests for non-Postgres read-only mutation keyword guard."""
+
+import pytest
+
+from dal.util.read_only import validate_no_mutation_keywords
+
+
+def test_validate_no_mutation_keywords_allows_select():
+    """Allow pure SELECT statements."""
+    validate_no_mutation_keywords("SELECT id, name FROM users WHERE id = 1")
+
+
+def test_validate_no_mutation_keywords_ignores_comments():
+    """Ignore mutation keywords that appear only inside comments."""
+    validate_no_mutation_keywords(
+        """
+        SELECT 1
+        -- INSERT INTO users VALUES (1)
+        /* MERGE INTO users */
+        """
+    )
+
+
+def test_validate_no_mutation_keywords_rejects_insert_disguised_with_formatting():
+    """Reject keyword-split INSERT statements after comment stripping."""
+    with pytest.raises(PermissionError, match="INSERT"):
+        validate_no_mutation_keywords("IN/* spacing */SERT INTO users(id) VALUES (1)")
+
+
+def test_validate_no_mutation_keywords_rejects_merge():
+    """Reject MERGE statements."""
+    with pytest.raises(PermissionError, match="MERGE"):
+        validate_no_mutation_keywords(
+            "MERGE INTO users u USING staging s ON u.id = s.id WHEN MATCHED THEN UPDATE SET id = 1"
+        )
+
+
+def test_validate_no_mutation_keywords_rejects_call():
+    """Reject procedure calls."""
+    with pytest.raises(PermissionError, match="CALL"):
+        validate_no_mutation_keywords("CALL refresh_materialized_views()")

--- a/tests/unit/mcp_server/test_tenant_enforcement_providers.py
+++ b/tests/unit/mcp_server/test_tenant_enforcement_providers.py
@@ -1,0 +1,131 @@
+"""Provider tenant-enforcement behavior for execute_sql_query."""
+
+import json
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_server.tools.execute_sql_query import handler
+
+
+def _caps() -> SimpleNamespace:
+    return SimpleNamespace(
+        supports_column_metadata=True,
+        supports_cancel=True,
+        supports_pagination=True,
+        execution_model="sync",
+    )
+
+
+@asynccontextmanager
+async def _conn_ctx(rows: list[dict] | None = None):
+    class _Conn:
+        async def fetch(self, _sql, *_params):
+            return list(rows or [])
+
+    yield _Conn()
+
+
+@pytest.mark.asyncio
+async def test_postgres_provider_allows_tenant_scoped_execution():
+    """Allow tenant-scoped execution when provider supports tenant enforcement."""
+    with (
+        patch("mcp_server.utils.auth.validate_role", return_value=None),
+        patch("agent.validation.policy_enforcer.PolicyEnforcer.validate_sql"),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_query_target_provider",
+            return_value="postgres",
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.supports_tenant_scope_enforcement",
+            return_value=True,
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_query_target_capabilities",
+            return_value=_caps(),
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_connection",
+            return_value=_conn_ctx(rows=[{"ok": 1}]),
+        ),
+    ):
+        payload = await handler("SELECT 1 AS ok", tenant_id=1)
+
+    result = json.loads(payload)
+    assert result.get("error") is None
+    assert result["rows"] == [{"ok": 1}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "provider",
+    [
+        "sqlite",
+        "mysql",
+        "snowflake",
+        "duckdb",
+        "clickhouse",
+        "redshift",
+        "bigquery",
+        "athena",
+        "databricks",
+    ],
+)
+async def test_non_postgres_provider_rejects_tenant_scoped_execution(provider: str):
+    """Reject tenant-scoped execution for providers without tenant enforcement."""
+    mock_connection = MagicMock()
+    with (
+        patch("mcp_server.utils.auth.validate_role", return_value=None),
+        patch("agent.validation.policy_enforcer.PolicyEnforcer.validate_sql"),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_query_target_provider",
+            return_value=provider,
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.supports_tenant_scope_enforcement",
+            return_value=False,
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_connection",
+            mock_connection,
+        ),
+    ):
+        payload = await handler("SELECT 1", tenant_id=1)
+
+    result = json.loads(payload)
+    assert result["error"]["category"] == "TENANT_ENFORCEMENT_UNSUPPORTED"
+    assert result["error"]["message"] == f"Tenant isolation not supported for provider {provider}"
+    mock_connection.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_postgres_tenant_bypass_flag_allows_legacy_behavior(monkeypatch):
+    """Allow legacy non-Postgres behavior when bypass flag is explicitly enabled."""
+    monkeypatch.setenv("ALLOW_NON_POSTGRES_TENANT_BYPASS", "true")
+    with (
+        patch("mcp_server.utils.auth.validate_role", return_value=None),
+        patch("agent.validation.policy_enforcer.PolicyEnforcer.validate_sql"),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_query_target_provider",
+            return_value="sqlite",
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.supports_tenant_scope_enforcement",
+            return_value=False,
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_query_target_capabilities",
+            return_value=_caps(),
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_connection",
+            return_value=_conn_ctx(rows=[{"ok": 1}]),
+        ),
+    ):
+        payload = await handler("SELECT 1 AS ok", tenant_id=7)
+
+    result = json.loads(payload)
+    assert result.get("error") is None
+    assert result["rows"] == [{"ok": 1}]

--- a/tests/unit/mcp_server/tools/test_execute_sql_query.py
+++ b/tests/unit/mcp_server/tools/test_execute_sql_query.py
@@ -360,6 +360,10 @@ class TestExecuteSqlQuery:
             patch(
                 "mcp_server.tools.execute_sql_query.Database.get_connection", mock_get_connection
             ),
+            patch(
+                "mcp_server.tools.execute_sql_query.Database.supports_tenant_scope_enforcement",
+                return_value=True,
+            ),
             patch("mcp_server.utils.auth.validate_role", return_value=None),
         ):
             result = await handler(sql_query, tenant_id=7)


### PR DESCRIPTION
This PR completes the second phase of tenant isolation hardening following multi-provider enforcement.

The initial enforcement branch ensured:

* Non-Postgres providers cannot silently execute tenant-scoped queries
* Mutation statements are rejected via defensive readonly guards

This follow-up strengthens correctness, cache behavior, and tenant scoping to eliminate residual drift and cross-tenant contamination risks.

Closes #720 

---

## What This Delivers

### 1. Consistent SQL Comment Stripping in PolicyEnforcer

**Problem**

`PolicyEnforcer.validate_sql()` previously parsed raw SQL without stripping comments, while other validation layers stripped comments first. This inconsistency weakened defense-in-depth.

**Change**

* Strip SQL comments before parsing in `PolicyEnforcer`.
* Align behavior with:

  * AST validator
  * MCP `_validate_sql_ast()`

**Impact**

* Eliminates comment-based parsing discrepancies.
* Ensures consistent mutation detection across layers.

---

### 2. TTL-Based Allowed Table Cache + Explicit Invalidation

**Problem**

Allowed table introspection used an unbounded LRU cache with no TTL.
This could cause silent policy drift in long-lived processes.

**Change**

* Replace LRU with TTL-based caching (default 5 minutes).
* Add explicit invalidation hook during schema refresh.
* Maintain thread safety.

**Impact**

* Prevents stale allowlist behavior.
* Aligns policy lifecycle with schema refresh lifecycle.
* Eliminates silent drift in production environments.

---

### 3. Non-Zero Default Schema Refresh Cooldown

**Problem**

Schema refresh cooldown defaulted to `0.0`, allowing potential thundering herd refreshes under concurrency.

**Change**

* Introduce a non-zero default cooldown.
* Preserve override capability via configuration.

**Impact**

* Stabilizes refresh behavior under schema churn.
* Reduces unnecessary refresh pressure.

---

### 4. Unit-Level Negative Tenant Isolation Tests

**Problem**

Tenant enforcement logic lacked CI-level negative tests ensuring:

* Unsupported providers reject tenant-scoped execution.
* DAL execution is not invoked when enforcement fails.

**Change**

* Added unit tests mocking DAL providers.
* Verified:

  * Structured error returned.
  * No query execution occurs.

**Impact**

* Prevents regression to silent tenant bypass.
* Moves isolation guarantees fully into CI.

---

### 5. Tenant Scoping for Ambiguity and Feedback Tools

**Problem**

`resolve_ambiguity` and `submit_feedback` previously lacked tenant scoping, allowing possible cross-tenant contamination.

**Change**

* Added `tenant_id` parameter.
* Enforced `require_tenant_id()`.
* Aligned role enforcement with other tools.

**Impact**

* Eliminates cross-tenant interaction leakage.
* Brings these tools into parity with the rest of the MCP surface.

---

## Security & Reliability Improvements

After this PR:

* No silent cross-tenant execution outside Postgres.
* No comment-based policy parsing inconsistencies.
* No long-lived allowlist cache drift.
* Schema refresh behavior stabilized.
* Ambiguity and feedback tools tenant-scoped.
* Isolation behavior fully covered by unit tests.

---

## Verification

* Full test suite passes.
* New tests validate:

  * Comment stripping behavior
  * TTL cache behavior and invalidation
  * Negative tenant enforcement cases
  * Tenant requirement for scoped tools
* Diff scoped to tenant enforcement follow-ups only.

---

## Out of Scope

* Cross-provider query rewriting
* Native RLS for non-Postgres engines
* Evaluation/metrics changes
* UI changes

---

## Resulting Posture

With this PR merged, tenant isolation is:

* Explicit
* Enforced
* Cache-consistent
* Covered by CI
* Resistant to silent bypass