### PR TITLE
Stable Keyset Pagination via ORDER BY Contract and Fail-Closed Guardrails

### DIFF
--- a/src/common/models/tool_envelopes.py
+++ b/src/common/models/tool_envelopes.py
@@ -195,6 +195,24 @@ class ExecuteSQLQueryMetadata(BaseModel):
         validation_alias="pagination.keyset.schema_stale",
         serialization_alias="pagination.keyset.schema_stale",
     )
+    pagination_keyset_order_contract: Optional[Literal["ok", "error"]] = Field(
+        None,
+        description="Status of keyset ORDER BY stability contract validation",
+        validation_alias="pagination.keyset.order_contract",
+        serialization_alias="pagination.keyset.order_contract",
+    )
+    pagination_keyset_order_reason_code: Optional[str] = Field(
+        None,
+        description="Bounded reason code when keyset ORDER BY contract fails",
+        validation_alias="pagination.keyset.order_reason_code",
+        serialization_alias="pagination.keyset.order_reason_code",
+    )
+    pagination_keyset_tiebreaker_present: Optional[bool] = Field(
+        None,
+        description="True when keyset ORDER BY includes a stable tie-breaker",
+        validation_alias="pagination.keyset.tiebreaker_present",
+        serialization_alias="pagination.keyset.tiebreaker_present",
+    )
     pagination_keyset_snapshot_strict: Optional[bool] = Field(
         None,
         description="True when strict snapshot requirements are enabled for keyset validation",

--- a/src/dal/pagination_cursor.py
+++ b/src/dal/pagination_cursor.py
@@ -31,7 +31,7 @@ Failure reason codes (bounded set)
   - ``PAGINATION_CURSOR_CLOCK_SKEW``       — issued_at too far in the future
   - ``PAGINATION_CURSOR_ISSUED_AT_INVALID``— missing or non-integer issued_at
   - ``PAGINATION_CURSOR_QUERY_MISMATCH``   — query fingerprint mismatch
-  - ``KEYSET_ORDER_MISMATCH``              — ORDER BY key drift
+  - ``KEYSET_CURSOR_ORDERBY_MISMATCH``     — ORDER BY key drift
   - ``KEYSET_SNAPSHOT_MISMATCH``           — cursor context drift (snapshot)
   - ``KEYSET_TOPOLOGY_MISMATCH``           — cursor context drift (topology)
   - ``KEYSET_SHARD_MISMATCH``              — cursor context drift (shard)

--- a/tests/unit/dal/test_keyset_pagination_cursor.py
+++ b/tests/unit/dal/test_keyset_pagination_cursor.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dal.keyset_pagination import (
-    KEYSET_ORDER_MISMATCH,
+    KEYSET_CURSOR_ORDERBY_MISMATCH,
     KEYSET_PARTITION_SET_CHANGED,
     KEYSET_SHARD_MISMATCH,
     KEYSET_SNAPSHOT_MISMATCH,
@@ -70,7 +70,7 @@ def test_keyset_cursor_secret_validation():
 def test_keyset_cursor_order_signature_rejects_direction_change():
     """Changing ORDER BY direction between pages must be rejected."""
     cursor = encode_keyset_cursor([123], ["id|asc|nulls_last"], "f1")
-    with pytest.raises(ValueError, match=KEYSET_ORDER_MISMATCH):
+    with pytest.raises(ValueError, match=KEYSET_CURSOR_ORDERBY_MISMATCH):
         decode_keyset_cursor(
             cursor,
             expected_fingerprint="f1",
@@ -81,7 +81,7 @@ def test_keyset_cursor_order_signature_rejects_direction_change():
 def test_keyset_cursor_order_signature_rejects_added_or_removed_key():
     """Changing ORDER BY key count between pages must be rejected."""
     cursor = encode_keyset_cursor([123], ["created_at|desc|nulls_first"], "f1")
-    with pytest.raises(ValueError, match=KEYSET_ORDER_MISMATCH):
+    with pytest.raises(ValueError, match=KEYSET_CURSOR_ORDERBY_MISMATCH):
         decode_keyset_cursor(
             cursor,
             expected_fingerprint="f1",
@@ -96,7 +96,7 @@ def test_keyset_cursor_order_signature_rejects_reordered_keys():
         ["created_at|desc|nulls_first", "id|asc|nulls_last"],
         "f1",
     )
-    with pytest.raises(ValueError, match=KEYSET_ORDER_MISMATCH):
+    with pytest.raises(ValueError, match=KEYSET_CURSOR_ORDERBY_MISMATCH):
         decode_keyset_cursor(
             cursor,
             expected_fingerprint="f1",

--- a/tests/unit/mcp_server/tools/test_cursor_signing_telemetry_invariants.py
+++ b/tests/unit/mcp_server/tools/test_cursor_signing_telemetry_invariants.py
@@ -177,7 +177,10 @@ async def test_error_response_does_not_leak_raw_cursor():
 async def test_reason_codes_are_bounded():
     """Reason codes in error responses must be from the known set."""
     known_reason_codes = {
-        "execution_pagination_keyset_order_by_required",
+        "KEYSET_ORDER_BY_REQUIRED",
+        "KEYSET_ORDER_BY_UNSAFE_EXPRESSION",
+        "KEYSET_ORDER_BY_AMBIGUOUS_COLUMN",
+        "KEYSET_ORDER_BY_MISSING_TIEBREAKER",
         "execution_pagination_keyset_cursor_invalid",
         "execution_pagination_keyset_invalid_sql",
         "execution_pagination_page_token_invalid",
@@ -185,11 +188,10 @@ async def test_reason_codes_are_bounded():
         "execution_pagination_page_size_invalid",
         "execution_pagination_page_size_exceeds_max_rows",
         "PAGINATION_MODE_TOKEN_MISMATCH",
-        "KEYSET_ORDER_MISMATCH",
+        "KEYSET_CURSOR_ORDERBY_MISMATCH",
         "KEYSET_SNAPSHOT_MISMATCH",
         "KEYSET_TOPOLOGY_MISMATCH",
         "KEYSET_REPLICA_LAG_UNSAFE",
-        "KEYSET_REQUIRES_STABLE_TIEBREAKER",
         "KEYSET_NULLABLE_TIEBREAKER_UNSAFE",
         "PAGINATION_FEDERATED_ORDERING_UNSAFE",
         "PAGINATION_FEDERATED_UNSUPPORTED",


### PR DESCRIPTION
## Summary
- enforce a stable keyset ORDER BY contract with fail-closed reason codes for missing ORDER BY, unsafe expressions, ambiguous multi-source columns, and missing tie-breakers
- tighten cursor-to-ORDER BY structural parity via normalized key signatures and reject drift with `KEYSET_CURSOR_ORDERBY_MISMATCH`
- add execute_sql_query guardrails and bounded telemetry for keyset order contract status (`pagination.keyset.order_contract`, `pagination.keyset.order_reason_code`, `pagination.keyset.tiebreaker_present`)
- extend DAL/MCP/agent parity tests and keyset contract coverage for the new reason-code contract and pre-execution safety behavior

Closes #783
