### PR TITLE
Adaptive Page Sizing from Remaining Pagination Session Budget

### DIFF
--- a/src/common/models/tool_envelopes.py
+++ b/src/common/models/tool_envelopes.py
@@ -177,6 +177,52 @@ class ExecuteSQLQueryMetadata(BaseModel):
         validation_alias="pagination.session.pages_served_bucket",
         serialization_alias="pagination.session.pages_served_bucket",
     )
+    pagination_session_page_size_requested: Optional[int] = Field(
+        None,
+        description="Requested page size before adaptive session-budget sizing",
+        validation_alias="pagination.session.page_size_requested",
+        serialization_alias="pagination.session.page_size_requested",
+    )
+    pagination_session_page_size_effective: Optional[int] = Field(
+        None,
+        description="Effective page size selected after adaptive session-budget sizing",
+        validation_alias="pagination.session.page_size_effective",
+        serialization_alias="pagination.session.page_size_effective",
+    )
+    pagination_session_page_size_adjusted: Optional[bool] = Field(
+        None,
+        description="True when session-budget adaptation reduced continuation page size",
+        validation_alias="pagination.session.page_size_adjusted",
+        serialization_alias="pagination.session.page_size_adjusted",
+    )
+    pagination_session_page_size_adjusted_reason_code: Optional[str] = Field(
+        None,
+        description="Stable reason code when continuation page size was adaptively reduced",
+        validation_alias="pagination.session.page_size_adjusted_reason_code",
+        serialization_alias="pagination.session.page_size_adjusted_reason_code",
+    )
+    pagination_session_remaining_rows_bucket: Optional[
+        Literal["0", "1_10", "11_100", "101_500", "501_plus"]
+    ] = Field(
+        None,
+        description="Bucketed remaining row budget before adaptive continuation sizing",
+        validation_alias="pagination.session.remaining_rows_bucket",
+        serialization_alias="pagination.session.remaining_rows_bucket",
+    )
+    pagination_session_remaining_bytes_bucket: Optional[
+        Literal["0", "1_1k", "1k_16k", "16k_256k", "256k_plus"]
+    ] = Field(
+        None,
+        description="Bucketed remaining byte budget before adaptive continuation sizing",
+        validation_alias="pagination.session.remaining_bytes_bucket",
+        serialization_alias="pagination.session.remaining_bytes_bucket",
+    )
+    pagination_session_no_safe_page: Optional[bool] = Field(
+        None,
+        description="True when no safe continuation page size could be served",
+        validation_alias="pagination.session.no_safe_page",
+        serialization_alias="pagination.session.no_safe_page",
+    )
     next_keyset_cursor: Optional[str] = Field(
         None, description="Opaque cursor for the next page when using keyset pagination"
     )

--- a/src/dal/execution_budget.py
+++ b/src/dal/execution_budget.py
@@ -13,6 +13,8 @@ PAGINATION_GLOBAL_ROW_BUDGET_EXCEEDED = "PAGINATION_GLOBAL_ROW_BUDGET_EXCEEDED"
 PAGINATION_GLOBAL_BYTE_BUDGET_EXCEEDED = "PAGINATION_GLOBAL_BYTE_BUDGET_EXCEEDED"
 PAGINATION_GLOBAL_TIME_BUDGET_EXCEEDED = "PAGINATION_GLOBAL_TIME_BUDGET_EXCEEDED"
 PAGINATION_BUDGET_SNAPSHOT_INVALID = "PAGINATION_BUDGET_SNAPSHOT_INVALID"
+PAGINATION_SESSION_NO_SAFE_PAGE_SIZE = "PAGINATION_SESSION_NO_SAFE_PAGE_SIZE"
+PAGINATION_SESSION_PAGE_SIZE_ADJUSTED = "PAGINATION_SESSION_PAGE_SIZE_ADJUSTED"
 
 _BUDGET_INT_MAX = 2_147_483_647
 
@@ -61,6 +63,40 @@ def _parse_positive_int(value: Any, *, field_name: str) -> int:
             f"Invalid pagination budget snapshot: {field_name} must be greater than zero."
         )
     return parsed
+
+
+def compute_effective_page_size(
+    requested_page_size: int,
+    remaining_row_budget: int | None,
+    remaining_byte_budget: int | None,
+    estimated_avg_row_bytes: int | None,
+) -> int:
+    """Compute the largest safe page size bounded by remaining session budgets."""
+    if isinstance(requested_page_size, bool):
+        return 0
+    requested = int(requested_page_size)
+    if requested <= 0:
+        return 0
+    effective_page_size = min(requested, _BUDGET_INT_MAX)
+
+    if remaining_row_budget is not None:
+        if isinstance(remaining_row_budget, bool):
+            return 0
+        bounded_remaining_rows = max(0, min(int(remaining_row_budget), _BUDGET_INT_MAX))
+        effective_page_size = min(effective_page_size, bounded_remaining_rows)
+
+    # Byte-budget sizing only applies when we have both a budget and a stable row-size estimate.
+    if remaining_byte_budget is not None and estimated_avg_row_bytes is not None:
+        if isinstance(remaining_byte_budget, bool) or isinstance(estimated_avg_row_bytes, bool):
+            return 0
+        bounded_remaining_bytes = max(0, min(int(remaining_byte_budget), _BUDGET_INT_MAX))
+        bounded_avg_row_bytes = max(1, min(int(estimated_avg_row_bytes), _BUDGET_INT_MAX))
+        byte_budget_limited_rows = bounded_remaining_bytes // bounded_avg_row_bytes
+        effective_page_size = min(effective_page_size, byte_budget_limited_rows)
+
+    if effective_page_size < 1:
+        return 0
+    return int(effective_page_size)
 
 
 @dataclass(frozen=True)

--- a/src/dal/pagination_session.py
+++ b/src/dal/pagination_session.py
@@ -50,6 +50,9 @@ class PaginationSession:
     is_revoked: bool = False
     last_accessed_at_ms: int | None = None
     pages_served_count: int = 0
+    avg_row_bytes_estimate: int | None = None
+    last_page_row_count: int | None = None
+    last_page_bytes: int | None = None
 
     def __post_init__(self) -> None:
         """Fail closed for malformed, unbounded, or unsafe session payloads."""
@@ -110,6 +113,21 @@ class PaginationSession:
             raise ValueError("Pagination session pages_served_count must be an integer.")
         if self.pages_served_count < 0 or self.pages_served_count > CURSOR_MAX_SIGNED_INT:
             raise ValueError("Pagination session pages_served_count is out of bounds.")
+        self._validate_optional_metric(
+            "avg_row_bytes_estimate",
+            self.avg_row_bytes_estimate,
+            allow_zero=False,
+        )
+        self._validate_optional_metric(
+            "last_page_row_count",
+            self.last_page_row_count,
+            allow_zero=True,
+        )
+        self._validate_optional_metric(
+            "last_page_bytes",
+            self.last_page_bytes,
+            allow_zero=True,
+        )
 
     @staticmethod
     def _validate_required_field(name: str, value: str, max_length: int) -> None:
@@ -120,6 +138,16 @@ class PaginationSession:
             raise ValueError(f"Pagination session {name} must not be empty.")
         if len(normalized) > max_length:
             raise ValueError(f"Pagination session {name} exceeds maximum length.")
+
+    @staticmethod
+    def _validate_optional_metric(name: str, value: int | None, *, allow_zero: bool) -> None:
+        if value is None:
+            return
+        if not isinstance(value, int):
+            raise ValueError(f"Pagination session {name} must be an integer when provided.")
+        minimum = 0 if allow_zero else 1
+        if value < minimum or value > CURSOR_MAX_SIGNED_INT:
+            raise ValueError(f"Pagination session {name} is out of bounds.")
 
 
 def generate_pagination_session_id() -> str:
@@ -180,7 +208,13 @@ class PaginationSessionRegistry(Protocol):
     def revoke(self, session_id: str) -> PaginationSession | None:
         """Backward-compatible alias for revoke_session."""
 
-    def record_access(self, session_id: str) -> PaginationSession | None:
+    def record_access(
+        self,
+        session_id: str,
+        *,
+        page_row_count: int | None = None,
+        page_bytes: int | None = None,
+    ) -> PaginationSession | None:
         """Increment continuation audit counters for a successful page retrieval."""
 
 
@@ -260,11 +294,19 @@ class InMemoryPaginationSessionRegistry(PaginationSessionRegistry):
         """Backward-compatible alias for revoke_session."""
         return self.revoke_session(session_id)
 
-    def record_access(self, session_id: str) -> PaginationSession | None:
+    def record_access(
+        self,
+        session_id: str,
+        *,
+        page_row_count: int | None = None,
+        page_bytes: int | None = None,
+    ) -> PaginationSession | None:
         """Update bounded audit state after a successful continuation request."""
         normalized_session_id = normalize_pagination_session_id(session_id)
         if normalized_session_id is None:
             return None
+        normalized_page_row_count = self._normalize_optional_metric(page_row_count)
+        normalized_page_bytes = self._normalize_optional_metric(page_bytes)
         now_ms = self._safe_now_ms()
         with self._lock:
             self._evict_expired_locked(now_ms)
@@ -272,10 +314,36 @@ class InMemoryPaginationSessionRegistry(PaginationSessionRegistry):
             if session is None or session.is_revoked:
                 return None
             next_pages_served_count = min(CURSOR_MAX_SIGNED_INT, session.pages_served_count + 1)
+            next_avg_row_bytes_estimate = session.avg_row_bytes_estimate
+            if (
+                normalized_page_row_count is not None
+                and normalized_page_bytes is not None
+                and normalized_page_row_count > 0
+            ):
+                sample_avg_row_bytes = max(1, normalized_page_bytes // normalized_page_row_count)
+                current_estimate = session.avg_row_bytes_estimate
+                if current_estimate is None or current_estimate <= 0:
+                    next_avg_row_bytes_estimate = sample_avg_row_bytes
+                else:
+                    next_avg_row_bytes_estimate = min(
+                        CURSOR_MAX_SIGNED_INT,
+                        max(1, (int(current_estimate) * 3 + sample_avg_row_bytes) // 4),
+                    )
             updated = replace(
                 session,
                 pages_served_count=next_pages_served_count,
                 last_accessed_at_ms=now_ms,
+                avg_row_bytes_estimate=next_avg_row_bytes_estimate,
+                last_page_row_count=(
+                    normalized_page_row_count
+                    if normalized_page_row_count is not None
+                    else session.last_page_row_count
+                ),
+                last_page_bytes=(
+                    normalized_page_bytes
+                    if normalized_page_bytes is not None
+                    else session.last_page_bytes
+                ),
             )
             self._sessions[normalized_session_id] = updated
             self._sessions.move_to_end(normalized_session_id)
@@ -291,6 +359,20 @@ class InMemoryPaginationSessionRegistry(PaginationSessionRegistry):
         if now_ms < 0:
             return 0
         return min(now_ms, CURSOR_MAX_SIGNED_INT)
+
+    @staticmethod
+    def _normalize_optional_metric(value: int | None) -> int | None:
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return None
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return None
+        if parsed < 0:
+            return None
+        return min(parsed, CURSOR_MAX_SIGNED_INT)
 
     def _evict_expired_locked(self, now_ms: int) -> None:
         while self._sessions:
@@ -328,11 +410,17 @@ def revoke_session(
 def record_session_access(
     session_id: str,
     *,
+    page_row_count: int | None = None,
+    page_bytes: int | None = None,
     registry: PaginationSessionRegistry | None = None,
 ) -> PaginationSession | None:
     """Record successful continuation access in the provided/default registry."""
     active_registry = registry or get_default_pagination_session_registry()
-    return active_registry.record_access(session_id)
+    return active_registry.record_access(
+        session_id,
+        page_row_count=page_row_count,
+        page_bytes=page_bytes,
+    )
 
 
 def normalize_pagination_session_id(session_id: str) -> str | None:

--- a/src/mcp_server/tools/execute_sql_query.py
+++ b/src/mcp_server/tools/execute_sql_query.py
@@ -40,10 +40,13 @@ from dal.execution_budget import (
     PAGINATION_GLOBAL_BYTE_BUDGET_EXCEEDED,
     PAGINATION_GLOBAL_ROW_BUDGET_EXCEEDED,
     PAGINATION_GLOBAL_TIME_BUDGET_EXCEEDED,
+    PAGINATION_SESSION_NO_SAFE_PAGE_SIZE,
+    PAGINATION_SESSION_PAGE_SIZE_ADJUSTED,
     ExecutionBudget,
     ExecutionBudgetExceededError,
     ExecutionBudgetSnapshotError,
     bytes_remaining_bucket,
+    compute_effective_page_size,
     rows_remaining_bucket,
 )
 from dal.execution_resource_limits import ExecutionResourceLimits
@@ -198,6 +201,7 @@ _KEYSET_REJECTION_REASON_ALLOWLIST = {
     PAGINATION_SESSION_UNKNOWN,
     PAGINATION_SESSION_REVOKED,
     PAGINATION_SESSION_SCOPE_MISMATCH,
+    PAGINATION_SESSION_NO_SAFE_PAGE_SIZE,
     "KEYSET_CURSOR_ORDERBY_SIGNATURE_MISSING",
     PAGINATION_GLOBAL_ROW_BUDGET_EXCEEDED,
     PAGINATION_GLOBAL_BYTE_BUDGET_EXCEEDED,
@@ -235,6 +239,8 @@ _PAGINATION_BUDGET_REASON_ALLOWLIST = {
     PAGINATION_GLOBAL_BYTE_BUDGET_EXCEEDED,
     PAGINATION_GLOBAL_TIME_BUDGET_EXCEEDED,
     PAGINATION_BUDGET_SNAPSHOT_INVALID,
+    PAGINATION_SESSION_NO_SAFE_PAGE_SIZE,
+    PAGINATION_SESSION_PAGE_SIZE_ADJUSTED,
 }
 _CURSOR_VALIDATION_OUTCOME_ALLOWLIST = {
     "OK",
@@ -1884,6 +1890,16 @@ def _rolling_average_row_size_bytes(rows: Sequence[dict[str, Any]]) -> int | Non
     return max(1, int(round(running_average)))
 
 
+def _estimate_avg_row_bytes_from_execution_budget(budget: ExecutionBudget) -> int | None:
+    """Estimate row size from prior page consumption in a fail-closed conservative way."""
+    consumed_rows = max(0, int(getattr(budget, "consumed_rows", 0)))
+    consumed_bytes = max(0, int(getattr(budget, "consumed_bytes", 0)))
+    if consumed_rows <= 0 or consumed_bytes <= 0:
+        return None
+    # Ceiling division is intentionally conservative to avoid byte-budget overshoot.
+    return max(1, (consumed_bytes + consumed_rows - 1) // consumed_rows)
+
+
 def _record_result_contract_observability(
     *,
     partial: bool,
@@ -2910,6 +2926,28 @@ async def handler(
         return _construct_error_response(
             execution_started_at,
             message="Pagination request exceeds the configured global execution budget.",
+            category=ErrorCategory.INVALID_REQUEST,
+            provider=provider,
+            metadata={"reason_code": reason_code},
+            envelope_metadata=tenant_enforcement_metadata,
+        )
+
+    def _no_safe_page_size_response() -> str:
+        reason_code = PAGINATION_SESSION_NO_SAFE_PAGE_SIZE
+        _apply_execution_budget_metadata(
+            tenant_enforcement_metadata,
+            execution_budget,
+            reason_code=reason_code,
+        )
+        tenant_enforcement_metadata["pagination.reject_reason_code"] = reason_code
+        if pagination_mode == "keyset":
+            tenant_enforcement_metadata["pagination.keyset.rejection_reason_code"] = reason_code
+        return _construct_error_response(
+            execution_started_at,
+            message=(
+                "Pagination continuation cannot serve a safe page within the remaining "
+                "session budget."
+            ),
             category=ErrorCategory.INVALID_REQUEST,
             provider=provider,
             metadata={"reason_code": reason_code},
@@ -4204,6 +4242,37 @@ async def handler(
                     pre_exhaustion_reason = execution_budget.exhausted_reason_code()
                     if pre_exhaustion_reason is not None:
                         return _budget_violation_response(pre_exhaustion_reason)
+                    if effective_page_size is not None:
+                        requested_keyset_page_size = int(effective_page_size)
+                        estimated_avg_row_bytes = _estimate_avg_row_bytes_from_execution_budget(
+                            execution_budget
+                        )
+                        adaptive_keyset_page_size = compute_effective_page_size(
+                            requested_page_size=requested_keyset_page_size,
+                            remaining_row_budget=execution_budget.rows_remaining,
+                            remaining_byte_budget=execution_budget.bytes_remaining,
+                            estimated_avg_row_bytes=estimated_avg_row_bytes,
+                        )
+                        if adaptive_keyset_page_size <= 0:
+                            return _no_safe_page_size_response()
+                        if adaptive_keyset_page_size != requested_keyset_page_size:
+                            tenant_enforcement_metadata[
+                                "pagination.session.page_size_adjusted_reason_code"
+                            ] = PAGINATION_SESSION_PAGE_SIZE_ADJUSTED
+                        effective_page_size = adaptive_keyset_page_size
+                        applied_page_size = adaptive_keyset_page_size
+                        tenant_enforcement_metadata["pagination.keyset.adaptive_page_size"] = (
+                            adaptive_keyset_page_size
+                        )
+                        tenant_enforcement_metadata["pagination.keyset.effective_page_size"] = (
+                            adaptive_keyset_page_size
+                        )
+                        tenant_enforcement_metadata["pagination.keyset.page_size_effective"] = (
+                            adaptive_keyset_page_size
+                        )
+                        tenant_enforcement_metadata["pagination.keyset.byte_budget"] = (
+                            execution_budget.bytes_remaining
+                        )
                     if len(keyset_values) != len(keyset_order_keys):
                         return _construct_error_response(
                             execution_started_at,
@@ -4256,6 +4325,7 @@ async def handler(
                 """Fetch rows from the database."""
                 nonlocal columns, next_token, offset_decode_metadata, offset_next_token_payload
                 nonlocal execution_budget
+                nonlocal effective_page_size, applied_page_size
                 nonlocal pagination_session, pagination_session_id
                 nonlocal pagination_session_continuation_validated
                 fetch_page = getattr(conn, "fetch_page", None)
@@ -4399,6 +4469,35 @@ async def handler(
                                     "Pagination token limit does not match requested page_size."
                                 ),
                             )
+                        requested_offset_page_size = int(
+                            token_payload.limit
+                            if effective_page_size is None
+                            else int(effective_page_size)
+                        )
+                        estimated_avg_row_bytes = _estimate_avg_row_bytes_from_execution_budget(
+                            execution_budget
+                        )
+                        adaptive_offset_page_size = compute_effective_page_size(
+                            requested_page_size=requested_offset_page_size,
+                            remaining_row_budget=execution_budget.rows_remaining,
+                            remaining_byte_budget=execution_budget.bytes_remaining,
+                            estimated_avg_row_bytes=estimated_avg_row_bytes,
+                        )
+                        if adaptive_offset_page_size <= 0:
+                            raise OffsetPaginationTokenError(
+                                reason_code=PAGINATION_SESSION_NO_SAFE_PAGE_SIZE,
+                                message=(
+                                    "Pagination continuation cannot serve a safe page within the "
+                                    "remaining session budget."
+                                ),
+                            )
+                        if adaptive_offset_page_size != requested_offset_page_size:
+                            tenant_enforcement_metadata[
+                                "pagination.session.page_size_adjusted_reason_code"
+                            ] = PAGINATION_SESSION_PAGE_SIZE_ADJUSTED
+                        pagination_limit = adaptive_offset_page_size
+                        effective_page_size = adaptive_offset_page_size
+                        applied_page_size = adaptive_offset_page_size
                     if pagination_limit <= 0:
                         raise OffsetPaginationTokenError(
                             reason_code="execution_pagination_page_size_invalid",
@@ -4509,7 +4608,12 @@ async def handler(
         if conn is not None:
             tenant_enforcement_metadata.update(_extract_postgres_sandbox_metadata(conn))
 
-        if pagination_mode == "keyset" and applied_page_size is not None and applied_page_size > 0:
+        if (
+            pagination_mode == "keyset"
+            and not keyset_cursor
+            and applied_page_size is not None
+            and applied_page_size > 0
+        ):
             requested_page_size = int(applied_page_size)
             adaptive_page_size = requested_page_size
             byte_budget = max(0, int(resource_limits.max_bytes))

--- a/src/mcp_server/tools/execute_sql_query.py
+++ b/src/mcp_server/tools/execute_sql_query.py
@@ -318,6 +318,14 @@ _PAGINATION_SESSION_REASON_ALLOWLIST = {
     PAGINATION_SESSION_SCOPE_MISMATCH,
 }
 _PAGINATION_SESSION_PAGES_SERVED_BUCKET_ALLOWLIST = {"0", "1", "2_4", "5_9", "10_plus"}
+_PAGINATION_SESSION_REMAINING_ROWS_BUCKET_ALLOWLIST = {"0", "1_10", "11_100", "101_500", "501_plus"}
+_PAGINATION_SESSION_REMAINING_BYTES_BUCKET_ALLOWLIST = {
+    "0",
+    "1_1k",
+    "1k_16k",
+    "16k_256k",
+    "256k_plus",
+}
 
 
 @dataclass(frozen=True)
@@ -454,6 +462,115 @@ def _apply_pagination_session_failure_metadata(
         session_revoked=False,
         session_scope_match=False,
     )
+
+
+def _apply_pagination_session_page_size_metadata(
+    envelope_metadata: dict[str, Any],
+    *,
+    requested_page_size: int,
+    effective_page_size: int,
+    remaining_rows: int,
+    remaining_bytes: int,
+    no_safe_page: bool,
+) -> None:
+    """Attach bounded adaptive page-size decision metadata for session continuations."""
+    bounded_requested = max(0, int(requested_page_size))
+    bounded_effective = max(0, int(effective_page_size))
+    adjusted = bounded_effective != bounded_requested
+    envelope_metadata["pagination.session.page_size_requested"] = bounded_requested
+    envelope_metadata["pagination.session.page_size_effective"] = bounded_effective
+    envelope_metadata["pagination.session.page_size_adjusted"] = bool(adjusted)
+    envelope_metadata["pagination.session.page_size_adjusted_reason_code"] = (
+        PAGINATION_SESSION_PAGE_SIZE_ADJUSTED if adjusted else None
+    )
+    envelope_metadata["pagination.session.remaining_rows_bucket"] = rows_remaining_bucket(
+        remaining_rows
+    )
+    envelope_metadata["pagination.session.remaining_bytes_bucket"] = bytes_remaining_bucket(
+        remaining_bytes
+    )
+    envelope_metadata["pagination.session.no_safe_page"] = bool(no_safe_page)
+
+
+def _normalize_pagination_session_remaining_rows_bucket(raw_value: Any) -> str | None:
+    if not isinstance(raw_value, str):
+        return None
+    normalized = raw_value.strip()
+    if normalized in _PAGINATION_SESSION_REMAINING_ROWS_BUCKET_ALLOWLIST:
+        return normalized
+    return None
+
+
+def _normalize_pagination_session_remaining_bytes_bucket(raw_value: Any) -> str | None:
+    if not isinstance(raw_value, str):
+        return None
+    normalized = raw_value.strip()
+    if normalized in _PAGINATION_SESSION_REMAINING_BYTES_BUCKET_ALLOWLIST:
+        return normalized
+    return None
+
+
+def _record_pagination_session_page_size_observability(metadata: dict[str, Any] | None) -> None:
+    session_metadata = metadata if isinstance(metadata, dict) else {}
+    requested_raw = session_metadata.get("pagination.session.page_size_requested")
+    effective_raw = session_metadata.get("pagination.session.page_size_effective")
+    requested = (
+        int(requested_raw)
+        if isinstance(requested_raw, int)
+        and not isinstance(requested_raw, bool)
+        and requested_raw >= 0
+        else None
+    )
+    effective = (
+        int(effective_raw)
+        if isinstance(effective_raw, int)
+        and not isinstance(effective_raw, bool)
+        and effective_raw >= 0
+        else None
+    )
+    adjusted_raw = session_metadata.get("pagination.session.page_size_adjusted")
+    adjusted = bool(adjusted_raw) if adjusted_raw is not None else None
+    no_safe_raw = session_metadata.get("pagination.session.no_safe_page")
+    no_safe = bool(no_safe_raw) if no_safe_raw is not None else None
+    remaining_rows_bucket = _normalize_pagination_session_remaining_rows_bucket(
+        session_metadata.get("pagination.session.remaining_rows_bucket")
+    )
+    remaining_bytes_bucket = _normalize_pagination_session_remaining_bytes_bucket(
+        session_metadata.get("pagination.session.remaining_bytes_bucket")
+    )
+
+    span = trace.get_current_span()
+    if span is not None and span.is_recording():
+        if requested is not None:
+            span.set_attribute("pagination.session.page_size_requested", requested)
+        if effective is not None:
+            span.set_attribute("pagination.session.page_size_effective", effective)
+        if adjusted is not None:
+            span.set_attribute("pagination.session.page_size_adjusted", adjusted)
+        if remaining_rows_bucket is not None:
+            span.set_attribute("pagination.session.remaining_rows_bucket", remaining_rows_bucket)
+        if remaining_bytes_bucket is not None:
+            span.set_attribute("pagination.session.remaining_bytes_bucket", remaining_bytes_bucket)
+        if no_safe is not None:
+            span.set_attribute("pagination.session.no_safe_page", no_safe)
+
+    if adjusted:
+        mcp_metrics.add_counter(
+            "pagination.session.page_size_adjustments_total",
+            description=(
+                "Count of pagination-session continuation requests with adaptive "
+                "page-size reduction"
+            ),
+            attributes={"tool_name": TOOL_NAME},
+        )
+    if no_safe:
+        mcp_metrics.add_counter(
+            "pagination.session.no_safe_page_total",
+            description=(
+                "Count of pagination-session continuation rejections with no safe page size"
+            ),
+            attributes={"tool_name": TOOL_NAME},
+        )
 
 
 def _tenant_enforcement_observability_fields(
@@ -2509,6 +2626,7 @@ def _construct_error_response(
     _record_cursor_secret_observability(envelope_meta)
     _record_keyset_schema_observability(envelope_meta)
     _record_execution_budget_observability(envelope_meta)
+    _record_pagination_session_page_size_observability(envelope_meta)
 
     envelope = ExecuteSQLQueryResponseEnvelope(
         rows=[],
@@ -2877,6 +2995,13 @@ async def handler(
         "pagination.session.pages_served_bucket": "0",
         "pagination.session.last_accessed_at_ms": None,
         "pagination.session.pages_served_count": None,
+        "pagination.session.page_size_requested": None,
+        "pagination.session.page_size_effective": None,
+        "pagination.session.page_size_adjusted": None,
+        "pagination.session.page_size_adjusted_reason_code": None,
+        "pagination.session.remaining_rows_bucket": None,
+        "pagination.session.remaining_bytes_bucket": None,
+        "pagination.session.no_safe_page": None,
         "execution_timeout_applied": execution_timeout_applied,
         "execution_timeout_triggered": False,
         "resource_capability_mismatch": None,
@@ -2942,8 +3067,16 @@ async def handler(
             envelope_metadata=tenant_enforcement_metadata,
         )
 
-    def _no_safe_page_size_response() -> str:
+    def _no_safe_page_size_response(*, requested_page_size: int) -> str:
         reason_code = PAGINATION_SESSION_NO_SAFE_PAGE_SIZE
+        _apply_pagination_session_page_size_metadata(
+            tenant_enforcement_metadata,
+            requested_page_size=requested_page_size,
+            effective_page_size=0,
+            remaining_rows=execution_budget.rows_remaining,
+            remaining_bytes=execution_budget.bytes_remaining,
+            no_safe_page=True,
+        )
         _apply_execution_budget_metadata(
             tenant_enforcement_metadata,
             execution_budget,
@@ -4268,11 +4401,17 @@ async def handler(
                             estimated_avg_row_bytes=estimated_avg_row_bytes,
                         )
                         if adaptive_keyset_page_size <= 0:
-                            return _no_safe_page_size_response()
-                        if adaptive_keyset_page_size != requested_keyset_page_size:
-                            tenant_enforcement_metadata[
-                                "pagination.session.page_size_adjusted_reason_code"
-                            ] = PAGINATION_SESSION_PAGE_SIZE_ADJUSTED
+                            return _no_safe_page_size_response(
+                                requested_page_size=requested_keyset_page_size
+                            )
+                        _apply_pagination_session_page_size_metadata(
+                            tenant_enforcement_metadata,
+                            requested_page_size=requested_keyset_page_size,
+                            effective_page_size=adaptive_keyset_page_size,
+                            remaining_rows=execution_budget.rows_remaining,
+                            remaining_bytes=execution_budget.bytes_remaining,
+                            no_safe_page=False,
+                        )
                         effective_page_size = adaptive_keyset_page_size
                         applied_page_size = adaptive_keyset_page_size
                         tenant_enforcement_metadata["pagination.keyset.adaptive_page_size"] = (
@@ -4502,6 +4641,14 @@ async def handler(
                             estimated_avg_row_bytes=estimated_avg_row_bytes,
                         )
                         if adaptive_offset_page_size <= 0:
+                            _apply_pagination_session_page_size_metadata(
+                                tenant_enforcement_metadata,
+                                requested_page_size=requested_offset_page_size,
+                                effective_page_size=0,
+                                remaining_rows=execution_budget.rows_remaining,
+                                remaining_bytes=execution_budget.bytes_remaining,
+                                no_safe_page=True,
+                            )
                             raise OffsetPaginationTokenError(
                                 reason_code=PAGINATION_SESSION_NO_SAFE_PAGE_SIZE,
                                 message=(
@@ -4509,10 +4656,14 @@ async def handler(
                                     "remaining session budget."
                                 ),
                             )
-                        if adaptive_offset_page_size != requested_offset_page_size:
-                            tenant_enforcement_metadata[
-                                "pagination.session.page_size_adjusted_reason_code"
-                            ] = PAGINATION_SESSION_PAGE_SIZE_ADJUSTED
+                        _apply_pagination_session_page_size_metadata(
+                            tenant_enforcement_metadata,
+                            requested_page_size=requested_offset_page_size,
+                            effective_page_size=adaptive_offset_page_size,
+                            remaining_rows=execution_budget.rows_remaining,
+                            remaining_bytes=execution_budget.bytes_remaining,
+                            no_safe_page=False,
+                        )
                         pagination_limit = adaptive_offset_page_size
                         effective_page_size = adaptive_offset_page_size
                         applied_page_size = adaptive_offset_page_size
@@ -5067,6 +5218,29 @@ async def handler(
                 "pagination.session.pages_served_bucket": tenant_enforcement_metadata.get(
                     "pagination.session.pages_served_bucket"
                 ),
+                "pagination.session.page_size_requested": tenant_enforcement_metadata.get(
+                    "pagination.session.page_size_requested"
+                ),
+                "pagination.session.page_size_effective": tenant_enforcement_metadata.get(
+                    "pagination.session.page_size_effective"
+                ),
+                "pagination.session.page_size_adjusted": tenant_enforcement_metadata.get(
+                    "pagination.session.page_size_adjusted"
+                ),
+                "pagination.session.page_size_adjusted_reason_code": (
+                    tenant_enforcement_metadata.get(
+                        "pagination.session.page_size_adjusted_reason_code"
+                    )
+                ),
+                "pagination.session.remaining_rows_bucket": tenant_enforcement_metadata.get(
+                    "pagination.session.remaining_rows_bucket"
+                ),
+                "pagination.session.remaining_bytes_bucket": tenant_enforcement_metadata.get(
+                    "pagination.session.remaining_bytes_bucket"
+                ),
+                "pagination.session.no_safe_page": tenant_enforcement_metadata.get(
+                    "pagination.session.no_safe_page"
+                ),
                 "pagination.keyset.replica_lag_seconds": tenant_enforcement_metadata.get(
                     "pagination.keyset.replica_lag_seconds"
                 ),
@@ -5193,6 +5367,7 @@ async def handler(
         _record_cursor_secret_observability(tenant_enforcement_metadata)
         _record_keyset_schema_observability(tenant_enforcement_metadata)
         _record_execution_budget_observability(tenant_enforcement_metadata)
+        _record_pagination_session_page_size_observability(tenant_enforcement_metadata)
         _record_result_contract_observability(
             partial=is_truncated,
             partial_reason=partial_reason,

--- a/src/mcp_server/tools/execute_sql_query.py
+++ b/src/mcp_server/tools/execute_sql_query.py
@@ -1900,6 +1900,16 @@ def _estimate_avg_row_bytes_from_execution_budget(budget: ExecutionBudget) -> in
     return max(1, (consumed_bytes + consumed_rows - 1) // consumed_rows)
 
 
+def _session_avg_row_bytes_estimate(session: Any) -> int | None:
+    """Return bounded row-size estimate from session state when present."""
+    raw_estimate = getattr(session, "avg_row_bytes_estimate", None)
+    if isinstance(raw_estimate, bool) or not isinstance(raw_estimate, int):
+        return None
+    if raw_estimate <= 0:
+        return None
+    return int(raw_estimate)
+
+
 def _record_result_contract_observability(
     *,
     partial: bool,
@@ -4244,9 +4254,13 @@ async def handler(
                         return _budget_violation_response(pre_exhaustion_reason)
                     if effective_page_size is not None:
                         requested_keyset_page_size = int(effective_page_size)
-                        estimated_avg_row_bytes = _estimate_avg_row_bytes_from_execution_budget(
-                            execution_budget
+                        estimated_avg_row_bytes = _session_avg_row_bytes_estimate(
+                            pagination_session
                         )
+                        if estimated_avg_row_bytes is None:
+                            estimated_avg_row_bytes = _estimate_avg_row_bytes_from_execution_budget(
+                                execution_budget
+                            )
                         adaptive_keyset_page_size = compute_effective_page_size(
                             requested_page_size=requested_keyset_page_size,
                             remaining_row_budget=execution_budget.rows_remaining,
@@ -4474,9 +4488,13 @@ async def handler(
                             if effective_page_size is None
                             else int(effective_page_size)
                         )
-                        estimated_avg_row_bytes = _estimate_avg_row_bytes_from_execution_budget(
-                            execution_budget
+                        estimated_avg_row_bytes = _session_avg_row_bytes_estimate(
+                            pagination_session
                         )
+                        if estimated_avg_row_bytes is None:
+                            estimated_avg_row_bytes = _estimate_avg_row_bytes_from_execution_budget(
+                                execution_budget
+                            )
                         adaptive_offset_page_size = compute_effective_page_size(
                             requested_page_size=requested_offset_page_size,
                             remaining_row_budget=execution_budget.rows_remaining,
@@ -4829,7 +4847,11 @@ async def handler(
         cap_mitigation_applied = False
         cap_mitigation_mode = "none"
         if pagination_session_continuation_validated and pagination_session_id is not None:
-            updated_session = pagination_session_registry.record_access(pagination_session_id)
+            updated_session = pagination_session_registry.record_access(
+                pagination_session_id,
+                page_row_count=len(result_rows),
+                page_bytes=bytes_returned,
+            )
             if updated_session is None:
                 reason_code = PAGINATION_SESSION_UNKNOWN
                 current_session = pagination_session_registry.get(pagination_session_id)

--- a/tests/unit/agent/test_federated_pagination_classification_parity.py
+++ b/tests/unit/agent/test_federated_pagination_classification_parity.py
@@ -869,6 +869,12 @@ async def test_global_row_budget_classification_parity_between_mcp_ast_and_agent
         rows_by_call=[[{"id": 1000 + i} for i in range(31)]],
     )
     assert "error" not in page_two
+    assert page_two["metadata"]["pagination.session.page_size_adjusted"] is True
+    assert page_two["metadata"]["pagination.session.no_safe_page"] is False
+    assert page_two["metadata"].get("pagination.reject_reason_code") is None
+    agent_page_two = await _run_agent_with_tool_payload(page_two)
+    assert agent_page_two.get("error") is None
+    assert agent_page_two.get("error_category") is None
     cursor_two = page_two["metadata"]["next_keyset_cursor"]
     assert cursor_two
 

--- a/tests/unit/agent/test_federated_pagination_classification_parity.py
+++ b/tests/unit/agent/test_federated_pagination_classification_parity.py
@@ -868,12 +868,23 @@ async def test_global_row_budget_classification_parity_between_mcp_ast_and_agent
         page_size=30,
         rows_by_call=[[{"id": 1000 + i} for i in range(31)]],
     )
-    await _assert_agent_reason_parity(page_two, "PAGINATION_GLOBAL_ROW_BUDGET_EXCEEDED")
+    assert "error" not in page_two
+    cursor_two = page_two["metadata"]["next_keyset_cursor"]
+    assert cursor_two
+
+    page_three = await _invoke_mcp_federated_keyset(
+        caps,
+        sql=sql,
+        keyset_cursor=cursor_two,
+        page_size=30,
+        rows_by_call=[[{"id": 2000 + i} for i in range(31)]],
+    )
+    await _assert_agent_reason_parity(page_three, "PAGINATION_GLOBAL_ROW_BUDGET_EXCEEDED")
 
 
 @pytest.mark.asyncio
 async def test_global_byte_budget_classification_parity_between_mcp_ast_and_agent(monkeypatch):
-    """Byte-budget rejection classification should match across AST, MCP envelope, and agent."""
+    """No-safe-page byte-budget rejection should preserve MCP/agent classification parity."""
     caps = BackendCapabilities(
         provider_name="federated-db",
         execution_topology="federated",
@@ -909,7 +920,7 @@ async def test_global_byte_budget_classification_parity_between_mcp_ast_and_agen
         page_size=1,
         rows_by_call=[[{"id": 3, "blob": "x" * 128}, {"id": 4, "blob": "y" * 128}]],
     )
-    await _assert_agent_reason_parity(page_two, "PAGINATION_GLOBAL_BYTE_BUDGET_EXCEEDED")
+    await _assert_agent_reason_parity(page_two, "PAGINATION_SESSION_NO_SAFE_PAGE_SIZE")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/dal/test_execution_budget.py
+++ b/tests/unit/dal/test_execution_budget.py
@@ -8,6 +8,7 @@ from dal.execution_budget import (
     ExecutionBudget,
     ExecutionBudgetExceededError,
     ExecutionBudgetSnapshotError,
+    compute_effective_page_size,
 )
 
 
@@ -87,3 +88,60 @@ def test_execution_budget_consume_rejects_when_row_budget_exceeded():
         budget.consume(rows=21, bytes_returned=100, duration_ms=50)
 
     assert exc_info.value.reason_code == PAGINATION_GLOBAL_ROW_BUDGET_EXCEEDED
+
+
+def test_compute_effective_page_size_respects_remaining_row_budget() -> None:
+    """Row budget should cap effective page size deterministically."""
+    assert (
+        compute_effective_page_size(
+            requested_page_size=100,
+            remaining_row_budget=25,
+            remaining_byte_budget=None,
+            estimated_avg_row_bytes=None,
+        )
+        == 25
+    )
+
+
+def test_compute_effective_page_size_respects_remaining_byte_budget() -> None:
+    """Byte budget + row estimate should cap effective page size deterministically."""
+    assert (
+        compute_effective_page_size(
+            requested_page_size=100,
+            remaining_row_budget=None,
+            remaining_byte_budget=1_000,
+            estimated_avg_row_bytes=100,
+        )
+        == 10
+    )
+
+
+def test_compute_effective_page_size_returns_zero_when_no_safe_page() -> None:
+    """Zero remaining budget should fail closed with no safe page."""
+    assert (
+        compute_effective_page_size(
+            requested_page_size=100,
+            remaining_row_budget=0,
+            remaining_byte_budget=None,
+            estimated_avg_row_bytes=None,
+        )
+        == 0
+    )
+
+
+def test_compute_effective_page_size_missing_byte_estimate_is_deterministic() -> None:
+    """Missing byte estimate must fall back to row-budget-only sizing."""
+    first = compute_effective_page_size(
+        requested_page_size=100,
+        remaining_row_budget=25,
+        remaining_byte_budget=10,
+        estimated_avg_row_bytes=None,
+    )
+    second = compute_effective_page_size(
+        requested_page_size=100,
+        remaining_row_budget=25,
+        remaining_byte_budget=10,
+        estimated_avg_row_bytes=None,
+    )
+    assert first == 25
+    assert second == 25

--- a/tests/unit/dal/test_pagination_session_registry.py
+++ b/tests/unit/dal/test_pagination_session_registry.py
@@ -1,4 +1,5 @@
 import re
+from dataclasses import replace
 
 import pytest
 
@@ -131,6 +132,81 @@ def test_record_access_returns_none_for_revoked_session() -> None:
     assert loaded.is_revoked is True
     assert loaded.pages_served_count == 0
     assert loaded.last_accessed_at_ms is None
+
+
+def test_record_access_updates_bounded_row_size_estimate_after_successful_page() -> None:
+    """Successful continuation pages should update rolling row-size estimate deterministically."""
+    now_state = {"value": 1_700_000_000_000}
+    registry = InMemoryPaginationSessionRegistry(now_ms=lambda: now_state["value"])
+    session = create_pagination_session(
+        tenant_id="tenant-12",
+        provider_name="postgres",
+        pagination_mode="offset",
+        query_scope_fp="scope-fp-12",
+        policy_snapshot_fp="policy-fp-12",
+        revocation_epoch=0,
+        now_epoch_milliseconds=now_state["value"],
+    )
+    registry.put(session)
+
+    now_state["value"] = 1_700_000_000_100
+    first = registry.record_access(
+        session.session_id,
+        page_row_count=2,
+        page_bytes=200,
+    )
+    now_state["value"] = 1_700_000_000_200
+    second = registry.record_access(
+        session.session_id,
+        page_row_count=4,
+        page_bytes=600,
+    )
+
+    assert first is not None
+    assert first.avg_row_bytes_estimate == 100
+    assert first.last_page_row_count == 2
+    assert first.last_page_bytes == 200
+    assert second is not None
+    # Weighted update: (100*3 + 150) // 4 = 112
+    assert second.avg_row_bytes_estimate == 112
+    assert second.last_page_row_count == 4
+    assert second.last_page_bytes == 600
+
+
+def test_record_access_on_rejected_session_does_not_mutate_row_size_estimate() -> None:
+    """Rejected continuation attempts must not mutate rolling row-size state."""
+    now_state = {"value": 1_700_000_000_000}
+    registry = InMemoryPaginationSessionRegistry(now_ms=lambda: now_state["value"])
+    base_session = create_pagination_session(
+        tenant_id="tenant-13",
+        provider_name="postgres",
+        pagination_mode="keyset",
+        query_scope_fp="scope-fp-13",
+        policy_snapshot_fp="policy-fp-13",
+        revocation_epoch=0,
+        now_epoch_milliseconds=now_state["value"],
+    )
+    seeded_session = replace(
+        base_session,
+        avg_row_bytes_estimate=120,
+        last_page_row_count=3,
+        last_page_bytes=360,
+    )
+    registry.put(seeded_session)
+    registry.revoke_session(seeded_session.session_id)
+
+    updated = registry.record_access(
+        seeded_session.session_id,
+        page_row_count=10,
+        page_bytes=10_000,
+    )
+    loaded = registry.get(seeded_session.session_id)
+
+    assert updated is None
+    assert loaded is not None
+    assert loaded.avg_row_bytes_estimate == 120
+    assert loaded.last_page_row_count == 3
+    assert loaded.last_page_bytes == 360
 
 
 def test_registry_ttl_expiry_evicts_stale_session() -> None:

--- a/tests/unit/mcp_server/test_execute_sql_pagination.py
+++ b/tests/unit/mcp_server/test_execute_sql_pagination.py
@@ -1,5 +1,6 @@
 """Tests for execute_sql_query pagination handling."""
 
+import asyncio
 import base64
 import hashlib
 import hmac
@@ -1825,6 +1826,206 @@ async def test_execute_sql_query_offset_rejected_continuation_does_not_mutate_se
     assert loaded.avg_row_bytes_estimate == 120
     assert loaded.last_page_row_count == 3
     assert loaded.last_page_bytes == 360
+
+
+@pytest.mark.asyncio
+async def test_execute_sql_query_offset_revocation_wins_over_adaptive_page_sizing(monkeypatch):
+    """Session revocation must reject before adaptive continuation page sizing is evaluated."""
+    caps = SimpleNamespace(
+        supports_column_metadata=True,
+        supports_cancel=True,
+        supports_pagination=False,
+        execution_model="sync",
+        supports_offset_pagination_wrapper=True,
+        supports_query_wrapping_subselect=True,
+    )
+    sql = "SELECT id FROM users ORDER BY id ASC"
+    monkeypatch.setenv("EXECUTION_RESOURCE_MAX_ROWS", "1000")
+    monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_ROW_LIMIT", "true")
+    monkeypatch.setenv("EXECUTION_RESOURCE_MAX_BYTES", "1000000")
+    monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_BYTE_LIMIT", "true")
+    monkeypatch.setenv("EXECUTION_RESOURCE_MAX_EXECUTION_MS", "100000")
+    monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_TIMEOUT", "true")
+
+    session = create_pagination_session(
+        tenant_id="1",
+        provider_name="postgres",
+        pagination_mode="offset",
+        query_scope_fp=_TEST_SCOPE_FP,
+        policy_snapshot_fp=_default_policy_snapshot_fp(),
+        revocation_epoch=0,
+    )
+    registry = get_default_pagination_session_registry()
+    registry.put(session)
+    registry.revoke_session(session.session_id)
+
+    limits = ExecutionResourceLimits.from_env()
+    fingerprint = build_query_fingerprint(
+        sql=sql,
+        params=[],
+        tenant_id=1,
+        provider="postgres",
+        max_rows=limits.max_rows,
+        max_bytes=limits.max_bytes,
+        max_execution_ms=limits.max_execution_ms,
+    )
+    token = encode_offset_pagination_token(
+        offset=0,
+        limit=10,
+        fingerprint=fingerprint,
+        issued_at=int(time.time()),
+        secret=_TEST_SECRET,
+        scope_fp=_TEST_SCOPE_FP,
+        budget_snapshot={
+            "max_total_rows": 1000,
+            "max_total_bytes": 50,
+            "max_total_duration_ms": 100000,
+            "consumed_rows": 0,
+            "consumed_bytes": 0,
+            "consumed_duration_ms": 0,
+        },
+        pagination_session_id=session.session_id,
+    )
+
+    class _Conn:
+        async def fetch(self, *_args, **_kwargs):
+            raise AssertionError("Revoked sessions should fail before SQL execution.")
+
+    @asynccontextmanager
+    async def _conn_ctx(*_args, **_kwargs):
+        yield _Conn()
+
+    with (
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_query_target_capabilities",
+            return_value=caps,
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_query_target_provider",
+            return_value="postgres",
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_connection",
+            side_effect=lambda *_args, **_kwargs: _conn_ctx(),
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.build_cursor_scope_fingerprint",
+            return_value=_TEST_SCOPE_FP,
+        ),
+        patch("agent.validation.policy_enforcer.PolicyEnforcer.validate_sql", return_value=None),
+        patch("mcp_server.utils.auth.validate_role", return_value=None),
+    ):
+        payload = await handler(sql, tenant_id=1, page_size=10, page_token=token)
+
+    result = json.loads(payload)
+    assert result["error"]["details_safe"]["reason_code"] == "PAGINATION_SESSION_REVOKED"
+    assert result["metadata"]["pagination.session.revoked"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_sql_query_offset_adaptive_continuation_still_respects_timeout(monkeypatch):
+    """Adaptive continuation sizing must not bypass hard timeout enforcement semantics."""
+    caps = SimpleNamespace(
+        supports_column_metadata=True,
+        supports_cancel=True,
+        supports_pagination=False,
+        execution_model="sync",
+        supports_offset_pagination_wrapper=True,
+        supports_query_wrapping_subselect=True,
+    )
+    sql = "SELECT id FROM users ORDER BY id ASC"
+    monkeypatch.setenv("EXECUTION_RESOURCE_MAX_ROWS", "100")
+    monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_ROW_LIMIT", "true")
+    monkeypatch.setenv("EXECUTION_RESOURCE_MAX_BYTES", "1000000")
+    monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_BYTE_LIMIT", "true")
+    monkeypatch.setenv("EXECUTION_RESOURCE_MAX_EXECUTION_MS", "100")
+    monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_TIMEOUT", "true")
+
+    session = create_pagination_session(
+        tenant_id="1",
+        provider_name="postgres",
+        pagination_mode="offset",
+        query_scope_fp=_TEST_SCOPE_FP,
+        policy_snapshot_fp=_default_policy_snapshot_fp(),
+        revocation_epoch=0,
+    )
+    get_default_pagination_session_registry().put(session)
+
+    limits = ExecutionResourceLimits.from_env()
+    fingerprint = build_query_fingerprint(
+        sql=sql,
+        params=[],
+        tenant_id=1,
+        provider="postgres",
+        max_rows=limits.max_rows,
+        max_bytes=limits.max_bytes,
+        max_execution_ms=limits.max_execution_ms,
+    )
+    token = encode_offset_pagination_token(
+        offset=0,
+        limit=20,
+        fingerprint=fingerprint,
+        issued_at=int(time.time()),
+        secret=_TEST_SECRET,
+        scope_fp=_TEST_SCOPE_FP,
+        budget_snapshot={
+            "max_total_rows": 100,
+            "max_total_bytes": 1000000,
+            "max_total_duration_ms": 100,
+            "consumed_rows": 90,
+            "consumed_bytes": 0,
+            "consumed_duration_ms": 0,
+        },
+        pagination_session_id=session.session_id,
+    )
+
+    class _Conn:
+        async def fetch(self, sql_text, *params):
+            _ = (sql_text, params)
+            return [{"id": i} for i in range(21)]
+
+    @asynccontextmanager
+    async def _conn_ctx(*_args, **_kwargs):
+        yield _Conn()
+
+    async def _timeout_after_fetch(operation, timeout_seconds, cancel=None, **_kwargs):
+        _ = (timeout_seconds, cancel)
+        await operation()
+        raise asyncio.TimeoutError("forced timeout")
+
+    with (
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_query_target_capabilities",
+            return_value=caps,
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_query_target_provider",
+            return_value="postgres",
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_connection",
+            side_effect=lambda *_args, **_kwargs: _conn_ctx(),
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.build_cursor_scope_fingerprint",
+            return_value=_TEST_SCOPE_FP,
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.run_with_timeout",
+            side_effect=_timeout_after_fetch,
+        ),
+        patch("agent.validation.policy_enforcer.PolicyEnforcer.validate_sql", return_value=None),
+        patch("mcp_server.utils.auth.validate_role", return_value=None),
+    ):
+        payload = await handler(sql, tenant_id=1, page_size=20, page_token=token)
+
+    result = json.loads(payload)
+    assert result["error"]["category"] == "timeout"
+    metadata = result["metadata"]
+    assert metadata["pagination.session.page_size_requested"] == 20
+    assert metadata["pagination.session.page_size_effective"] == 10
+    assert metadata["pagination.session.page_size_adjusted"] is True
+    assert metadata["pagination.session.no_safe_page"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp_server/test_execute_sql_pagination.py
+++ b/tests/unit/mcp_server/test_execute_sql_pagination.py
@@ -6,6 +6,7 @@ import hmac
 import json
 import time
 from contextlib import asynccontextmanager
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -1528,6 +1529,214 @@ async def test_execute_sql_query_offset_continuation_adapts_page_size_to_remaini
 
     assert third["error"]["category"] == "invalid_request"
     assert third["error"]["details_safe"]["reason_code"] == "PAGINATION_GLOBAL_ROW_BUDGET_EXCEEDED"
+
+
+@pytest.mark.asyncio
+async def test_execute_sql_query_offset_continuation_uses_session_row_size_estimate(monkeypatch):
+    """Continuation should use session rolling row-size estimate when budget snapshot lacks one."""
+    caps = SimpleNamespace(
+        supports_column_metadata=True,
+        supports_cancel=True,
+        supports_pagination=False,
+        execution_model="sync",
+        supports_offset_pagination_wrapper=True,
+        supports_query_wrapping_subselect=True,
+    )
+    sql = "SELECT id FROM users ORDER BY id ASC"
+    monkeypatch.setenv("EXECUTION_RESOURCE_MAX_ROWS", "1000")
+    monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_ROW_LIMIT", "true")
+    monkeypatch.setenv("EXECUTION_RESOURCE_MAX_BYTES", "1000000")
+    monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_BYTE_LIMIT", "true")
+    monkeypatch.setenv("EXECUTION_RESOURCE_MAX_EXECUTION_MS", "100000")
+    monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_TIMEOUT", "true")
+
+    base_session = create_pagination_session(
+        tenant_id="1",
+        provider_name="postgres",
+        pagination_mode="offset",
+        query_scope_fp=_TEST_SCOPE_FP,
+        policy_snapshot_fp=_default_policy_snapshot_fp(),
+        revocation_epoch=0,
+    )
+    seeded_session = replace(
+        base_session,
+        avg_row_bytes_estimate=60,
+        last_page_row_count=2,
+        last_page_bytes=120,
+    )
+    get_default_pagination_session_registry().put(seeded_session)
+
+    limits = ExecutionResourceLimits.from_env()
+    fingerprint = build_query_fingerprint(
+        sql=sql,
+        params=[],
+        tenant_id=1,
+        provider="postgres",
+        max_rows=limits.max_rows,
+        max_bytes=limits.max_bytes,
+        max_execution_ms=limits.max_execution_ms,
+    )
+    token = encode_offset_pagination_token(
+        offset=0,
+        limit=4,
+        fingerprint=fingerprint,
+        issued_at=int(time.time()),
+        secret=_TEST_SECRET,
+        scope_fp=_TEST_SCOPE_FP,
+        budget_snapshot={
+            "max_total_rows": 1000,
+            "max_total_bytes": 100,
+            "max_total_duration_ms": 100000,
+            "consumed_rows": 0,
+            "consumed_bytes": 0,
+            "consumed_duration_ms": 0,
+        },
+        pagination_session_id=seeded_session.session_id,
+    )
+
+    class _Conn:
+        async def fetch(self, sql_text, *params):
+            _ = params
+            if "LIMIT 2 OFFSET 0" in sql_text:
+                return [{"id": 1}, {"id": 2}]
+            return []
+
+    @asynccontextmanager
+    async def _conn_ctx(*_args, **_kwargs):
+        yield _Conn()
+
+    with (
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_query_target_capabilities",
+            return_value=caps,
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_query_target_provider",
+            return_value="postgres",
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_connection",
+            side_effect=lambda *_args, **_kwargs: _conn_ctx(),
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.build_cursor_scope_fingerprint",
+            return_value=_TEST_SCOPE_FP,
+        ),
+        patch("agent.validation.policy_enforcer.PolicyEnforcer.validate_sql", return_value=None),
+        patch("mcp_server.utils.auth.validate_role", return_value=None),
+    ):
+        payload = await handler(sql, tenant_id=1, page_size=4, page_token=token)
+
+    result = json.loads(payload)
+    assert "error" not in result
+    assert len(result["rows"]) == 1
+    assert result["metadata"]["page_size"] == 1
+    assert result["metadata"]["next_page_token"]
+
+
+@pytest.mark.asyncio
+async def test_execute_sql_query_offset_rejected_continuation_does_not_mutate_session_estimate(
+    monkeypatch,
+):
+    """Rejected continuation must not mutate session rolling row-size estimate fields."""
+    caps = SimpleNamespace(
+        supports_column_metadata=True,
+        supports_cancel=True,
+        supports_pagination=False,
+        execution_model="sync",
+        supports_offset_pagination_wrapper=True,
+        supports_query_wrapping_subselect=True,
+    )
+    sql = "SELECT id FROM users ORDER BY id ASC"
+    monkeypatch.setenv("EXECUTION_RESOURCE_MAX_ROWS", "1000")
+    monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_ROW_LIMIT", "true")
+    monkeypatch.setenv("EXECUTION_RESOURCE_MAX_BYTES", "1000000")
+    monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_BYTE_LIMIT", "true")
+    monkeypatch.setenv("EXECUTION_RESOURCE_MAX_EXECUTION_MS", "100000")
+    monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_TIMEOUT", "true")
+
+    base_session = create_pagination_session(
+        tenant_id="1",
+        provider_name="postgres",
+        pagination_mode="offset",
+        query_scope_fp=_TEST_SCOPE_FP,
+        policy_snapshot_fp=_default_policy_snapshot_fp(),
+        revocation_epoch=0,
+    )
+    seeded_session = replace(
+        base_session,
+        avg_row_bytes_estimate=120,
+        last_page_row_count=3,
+        last_page_bytes=360,
+    )
+    registry = get_default_pagination_session_registry()
+    registry.put(seeded_session)
+
+    limits = ExecutionResourceLimits.from_env()
+    fingerprint = build_query_fingerprint(
+        sql=sql,
+        params=[],
+        tenant_id=1,
+        provider="postgres",
+        max_rows=limits.max_rows,
+        max_bytes=limits.max_bytes,
+        max_execution_ms=limits.max_execution_ms,
+    )
+    token = encode_offset_pagination_token(
+        offset=0,
+        limit=4,
+        fingerprint=fingerprint,
+        issued_at=int(time.time()),
+        secret=_TEST_SECRET,
+        scope_fp=_TEST_SCOPE_FP,
+        budget_snapshot={
+            "max_total_rows": 1000,
+            "max_total_bytes": 50,
+            "max_total_duration_ms": 100000,
+            "consumed_rows": 0,
+            "consumed_bytes": 0,
+            "consumed_duration_ms": 0,
+        },
+        pagination_session_id=seeded_session.session_id,
+    )
+
+    class _Conn:
+        async def fetch(self, *_args, **_kwargs):
+            raise AssertionError("Continuation should fail before executing SQL.")
+
+    @asynccontextmanager
+    async def _conn_ctx(*_args, **_kwargs):
+        yield _Conn()
+
+    with (
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_query_target_capabilities",
+            return_value=caps,
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_query_target_provider",
+            return_value="postgres",
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_connection",
+            side_effect=lambda *_args, **_kwargs: _conn_ctx(),
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.build_cursor_scope_fingerprint",
+            return_value=_TEST_SCOPE_FP,
+        ),
+        patch("agent.validation.policy_enforcer.PolicyEnforcer.validate_sql", return_value=None),
+        patch("mcp_server.utils.auth.validate_role", return_value=None),
+    ):
+        payload = await handler(sql, tenant_id=1, page_size=4, page_token=token)
+
+    result = json.loads(payload)
+    assert result["error"]["details_safe"]["reason_code"] == "PAGINATION_SESSION_NO_SAFE_PAGE_SIZE"
+    loaded = registry.get(seeded_session.session_id)
+    assert loaded is not None
+    assert loaded.avg_row_bytes_estimate == 120
+    assert loaded.last_page_row_count == 3
+    assert loaded.last_page_bytes == 360
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp_server/test_execute_sql_pagination.py
+++ b/tests/unit/mcp_server/test_execute_sql_pagination.py
@@ -520,6 +520,7 @@ async def test_execute_sql_query_offset_pagination_token_mismatch_rejected():
             "mcp_server.tools.execute_sql_query.Database.get_connection",
             side_effect=lambda *_args, **_kwargs: _conn_ctx(),
         ),
+        patch("agent.validation.policy_enforcer.PolicyEnforcer.validate_sql", return_value=None),
         patch("mcp_server.utils.auth.validate_role", return_value=None),
     ):
         first_payload = await handler("SELECT 1 AS id", tenant_id=1, page_size=2)
@@ -1454,6 +1455,79 @@ async def test_execute_sql_query_offset_budget_snapshot_tamper_is_rejected():
     assert (
         result["metadata"]["pagination.reject_reason_code"] == "PAGINATION_BUDGET_SNAPSHOT_INVALID"
     )
+
+
+@pytest.mark.asyncio
+async def test_execute_sql_query_offset_continuation_adapts_page_size_to_remaining_row_budget(
+    monkeypatch,
+):
+    """Offset continuation should shrink page size to fit remaining row budget."""
+    caps = SimpleNamespace(
+        supports_column_metadata=True,
+        supports_cancel=True,
+        supports_pagination=False,
+        execution_model="sync",
+        supports_offset_pagination_wrapper=True,
+        supports_query_wrapping_subselect=True,
+    )
+    sql = "SELECT id FROM users ORDER BY id ASC"
+    monkeypatch.setenv("EXECUTION_RESOURCE_MAX_ROWS", "100")
+    monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_ROW_LIMIT", "true")
+    monkeypatch.setenv("EXECUTION_RESOURCE_MAX_BYTES", "1000000")
+    monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_BYTE_LIMIT", "true")
+    monkeypatch.setenv("EXECUTION_RESOURCE_MAX_EXECUTION_MS", "100000")
+    monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_TIMEOUT", "true")
+
+    class _Conn:
+        async def fetch(self, sql_text, *params):
+            _ = params
+            if "LIMIT 81 OFFSET 0" in sql_text:
+                return [{"id": i} for i in range(81)]
+            if "LIMIT 21 OFFSET 80" in sql_text:
+                return [{"id": 1_000 + i} for i in range(21)]
+            if "LIMIT 21 OFFSET 100" in sql_text:
+                return [{"id": 2_000 + i} for i in range(21)]
+            return []
+
+    @asynccontextmanager
+    async def _conn_ctx(*_args, **_kwargs):
+        yield _Conn()
+
+    with (
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_query_target_capabilities",
+            return_value=caps,
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_query_target_provider",
+            return_value="postgres",
+        ),
+        patch(
+            "mcp_server.tools.execute_sql_query.Database.get_connection",
+            side_effect=lambda *_args, **_kwargs: _conn_ctx(),
+        ),
+        patch("agent.validation.policy_enforcer.PolicyEnforcer.validate_sql", return_value=None),
+        patch("mcp_server.utils.auth.validate_role", return_value=None),
+    ):
+        first_payload = await handler(sql, tenant_id=1, page_size=80)
+        first = json.loads(first_payload)
+        assert "error" not in first
+        token = first["metadata"]["next_page_token"]
+        assert token
+
+        second_payload = await handler(sql, tenant_id=1, page_size=80, page_token=token)
+        second = json.loads(second_payload)
+        assert "error" not in second
+        assert len(second["rows"]) == 20
+        assert second["metadata"]["page_size"] == 20
+        next_token = second["metadata"]["next_page_token"]
+        assert next_token
+
+        third_payload = await handler(sql, tenant_id=1, page_size=80, page_token=next_token)
+        third = json.loads(third_payload)
+
+    assert third["error"]["category"] == "invalid_request"
+    assert third["error"]["details_safe"]["reason_code"] == "PAGINATION_GLOBAL_ROW_BUDGET_EXCEEDED"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp_server/test_execute_sql_pagination.py
+++ b/tests/unit/mcp_server/test_execute_sql_pagination.py
@@ -1478,6 +1478,8 @@ async def test_execute_sql_query_offset_continuation_adapts_page_size_to_remaini
     monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_BYTE_LIMIT", "true")
     monkeypatch.setenv("EXECUTION_RESOURCE_MAX_EXECUTION_MS", "100000")
     monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_TIMEOUT", "true")
+    mock_span = MagicMock()
+    mock_span.is_recording.return_value = True
 
     class _Conn:
         async def fetch(self, sql_text, *params):
@@ -1508,6 +1510,7 @@ async def test_execute_sql_query_offset_continuation_adapts_page_size_to_remaini
             side_effect=lambda *_args, **_kwargs: _conn_ctx(),
         ),
         patch("agent.validation.policy_enforcer.PolicyEnforcer.validate_sql", return_value=None),
+        patch("mcp_server.tools.execute_sql_query.trace.get_current_span", return_value=mock_span),
         patch("mcp_server.utils.auth.validate_role", return_value=None),
     ):
         first_payload = await handler(sql, tenant_id=1, page_size=80)
@@ -1516,11 +1519,55 @@ async def test_execute_sql_query_offset_continuation_adapts_page_size_to_remaini
         token = first["metadata"]["next_page_token"]
         assert token
 
+        mock_span.reset_mock()
         second_payload = await handler(sql, tenant_id=1, page_size=80, page_token=token)
         second = json.loads(second_payload)
         assert "error" not in second
         assert len(second["rows"]) == 20
         assert second["metadata"]["page_size"] == 20
+        metadata = second["metadata"]
+        assert metadata["pagination.session.page_size_requested"] == 80
+        assert metadata["pagination.session.page_size_effective"] == 20
+        assert metadata["pagination.session.page_size_adjusted"] is True
+        assert metadata["pagination.session.page_size_adjusted_reason_code"] == (
+            "PAGINATION_SESSION_PAGE_SIZE_ADJUSTED"
+        )
+        assert metadata["pagination.session.remaining_rows_bucket"] == "11_100"
+        assert metadata["pagination.session.remaining_bytes_bucket"] in {
+            "0",
+            "1_1k",
+            "1k_16k",
+            "16k_256k",
+            "256k_plus",
+        }
+        assert metadata["pagination.session.no_safe_page"] is False
+        attrs = {}
+        for call in mock_span.set_attribute.call_args_list:
+            key, value = call.args
+            attrs[key] = value
+        assert (
+            attrs["pagination.session.page_size_requested"]
+            == metadata["pagination.session.page_size_requested"]
+        )
+        assert (
+            attrs["pagination.session.page_size_effective"]
+            == metadata["pagination.session.page_size_effective"]
+        )
+        assert (
+            attrs["pagination.session.page_size_adjusted"]
+            == metadata["pagination.session.page_size_adjusted"]
+        )
+        assert (
+            attrs["pagination.session.remaining_rows_bucket"]
+            == metadata["pagination.session.remaining_rows_bucket"]
+        )
+        assert (
+            attrs["pagination.session.remaining_bytes_bucket"]
+            == metadata["pagination.session.remaining_bytes_bucket"]
+        )
+        assert (
+            attrs["pagination.session.no_safe_page"] == metadata["pagination.session.no_safe_page"]
+        )
         next_token = second["metadata"]["next_page_token"]
         assert next_token
 
@@ -1654,6 +1701,8 @@ async def test_execute_sql_query_offset_rejected_continuation_does_not_mutate_se
     monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_BYTE_LIMIT", "true")
     monkeypatch.setenv("EXECUTION_RESOURCE_MAX_EXECUTION_MS", "100000")
     monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_TIMEOUT", "true")
+    mock_span = MagicMock()
+    mock_span.is_recording.return_value = True
 
     base_session = create_pagination_session(
         tenant_id="1",
@@ -1726,12 +1775,51 @@ async def test_execute_sql_query_offset_rejected_continuation_does_not_mutate_se
             return_value=_TEST_SCOPE_FP,
         ),
         patch("agent.validation.policy_enforcer.PolicyEnforcer.validate_sql", return_value=None),
+        patch("mcp_server.tools.execute_sql_query.trace.get_current_span", return_value=mock_span),
         patch("mcp_server.utils.auth.validate_role", return_value=None),
     ):
         payload = await handler(sql, tenant_id=1, page_size=4, page_token=token)
 
     result = json.loads(payload)
     assert result["error"]["details_safe"]["reason_code"] == "PAGINATION_SESSION_NO_SAFE_PAGE_SIZE"
+    metadata = result["metadata"]
+    assert metadata["pagination.session.page_size_requested"] == 4
+    assert metadata["pagination.session.page_size_effective"] == 0
+    assert metadata["pagination.session.page_size_adjusted"] is True
+    assert metadata["pagination.session.page_size_adjusted_reason_code"] == (
+        "PAGINATION_SESSION_PAGE_SIZE_ADJUSTED"
+    )
+    assert metadata["pagination.session.remaining_rows_bucket"] == "501_plus"
+    assert metadata["pagination.session.remaining_bytes_bucket"] == "1_1k"
+    assert metadata["pagination.session.no_safe_page"] is True
+    attrs = {}
+    for call in mock_span.set_attribute.call_args_list:
+        key, value = call.args
+        attrs[key] = value
+    assert (
+        attrs["pagination.session.page_size_requested"]
+        == metadata["pagination.session.page_size_requested"]
+    )
+    assert (
+        attrs["pagination.session.page_size_effective"]
+        == metadata["pagination.session.page_size_effective"]
+    )
+    assert (
+        attrs["pagination.session.page_size_adjusted"]
+        == metadata["pagination.session.page_size_adjusted"]
+    )
+    assert (
+        attrs["pagination.session.remaining_rows_bucket"]
+        == metadata["pagination.session.remaining_rows_bucket"]
+    )
+    assert (
+        attrs["pagination.session.remaining_bytes_bucket"]
+        == metadata["pagination.session.remaining_bytes_bucket"]
+    )
+    assert attrs["pagination.session.no_safe_page"] == metadata["pagination.session.no_safe_page"]
+    serialized = json.dumps(result)
+    assert sql not in serialized
+    assert token not in serialized
     loaded = registry.get(seeded_session.session_id)
     assert loaded is not None
     assert loaded.avg_row_bytes_estimate == 120

--- a/tests/unit/mcp_server/tools/test_keyset_pagination_contract.py
+++ b/tests/unit/mcp_server/tools/test_keyset_pagination_contract.py
@@ -4817,6 +4817,100 @@ async def test_execute_sql_query_keyset_rejects_when_no_safe_page_size_can_be_se
 
 
 @pytest.mark.asyncio
+async def test_execute_sql_query_keyset_long_session_repeated_adaptive_shrink(monkeypatch):
+    """Long keyset chains should repeatedly shrink as session byte budget tightens."""
+    caps = SimpleNamespace(
+        provider_name="postgres",
+        tenant_enforcement_mode="rls_session",
+        supports_column_metadata=True,
+        supports_cancel=True,
+        supports_pagination=True,
+        execution_model="sync",
+    )
+    sql = "SELECT id, blob FROM users ORDER BY id ASC"
+    monkeypatch.setenv("EXECUTION_RESOURCE_MAX_ROWS", "1000")
+    monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_ROW_LIMIT", "true")
+    monkeypatch.setenv("EXECUTION_RESOURCE_MAX_BYTES", "1700")
+    monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_BYTE_LIMIT", "true")
+    monkeypatch.setenv("EXECUTION_RESOURCE_MAX_EXECUTION_MS", "100000")
+    monkeypatch.setenv("EXECUTION_RESOURCE_ENFORCE_TIMEOUT", "true")
+
+    with (
+        patch("dal.database.Database.get_query_target_capabilities", return_value=caps),
+        patch("dal.database.Database.get_query_target_provider", return_value="postgres"),
+        patch("dal.database.Database.get_connection") as mock_get_conn,
+        patch("agent.validation.policy_enforcer.PolicyEnforcer.validate_sql", return_value=None),
+        patch("mcp_server.utils.auth.validate_role", return_value=None),
+    ):
+
+        class _Conn:
+            def __init__(self):
+                self.session_guardrail_metadata = {}
+                self.calls = 0
+
+            async def fetch(self, _query, *_args):
+                self.calls += 1
+                if self.calls == 1:
+                    return [{"id": i, "blob": "a" * 20} for i in range(11)]
+                if self.calls == 2:
+                    return [{"id": 100 + i, "blob": "b" * 70} for i in range(11)]
+                if self.calls >= 3:
+                    return [{"id": 200 + i, "blob": "c" * 50} for i in range(11)]
+
+        mock_conn = _Conn()
+        mock_get_conn.return_value.__aenter__.return_value = mock_conn
+
+        page_one = json.loads(
+            await handler(sql, tenant_id=1, pagination_mode="keyset", page_size=10)
+        )
+        assert "error" not in page_one
+        cursor_one = page_one["metadata"]["next_keyset_cursor"]
+        assert cursor_one
+
+        page_two = json.loads(
+            await handler(
+                sql,
+                tenant_id=1,
+                pagination_mode="keyset",
+                keyset_cursor=cursor_one,
+                page_size=10,
+            )
+        )
+        assert "error" not in page_two
+        cursor_two = page_two["metadata"]["next_keyset_cursor"]
+        assert cursor_two
+
+        page_three = json.loads(
+            await handler(
+                sql,
+                tenant_id=1,
+                pagination_mode="keyset",
+                keyset_cursor=cursor_two,
+                page_size=10,
+            )
+        )
+        assert "error" not in page_three
+        cursor_three = page_three["metadata"]["next_keyset_cursor"]
+        assert cursor_three
+
+        page_four = json.loads(
+            await handler(
+                sql,
+                tenant_id=1,
+                pagination_mode="keyset",
+                keyset_cursor=cursor_three,
+                page_size=10,
+            )
+        )
+
+    assert page_two["metadata"]["page_size"] == 10
+    assert page_three["metadata"]["page_size"] < page_two["metadata"]["page_size"]
+    assert (
+        page_four["error"]["details_safe"]["reason_code"] == "PAGINATION_SESSION_NO_SAFE_PAGE_SIZE"
+    )
+
+
+@pytest.mark.asyncio
 async def test_execute_sql_query_keyset_rejects_when_global_time_budget_exceeded(monkeypatch):
     """Second page should fail closed when cumulative duration exceeds request budget."""
     caps = SimpleNamespace(

--- a/tests/unit/mcp_server/tools/test_keyset_pagination_contract.py
+++ b/tests/unit/mcp_server/tools/test_keyset_pagination_contract.py
@@ -4538,8 +4538,10 @@ async def test_execute_sql_query_keyset_budget_metadata_non_negative(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_execute_sql_query_keyset_rejects_when_global_row_budget_exceeded(monkeypatch):
-    """Second page should fail closed when cumulative rows exceed request budget."""
+async def test_execute_sql_query_keyset_continuation_adapts_page_size_to_remaining_row_budget(
+    monkeypatch,
+):
+    """Continuation should shrink keyset page size to remaining row budget before execution."""
     caps = SimpleNamespace(
         provider_name="postgres",
         tenant_enforcement_mode="rls_session",
@@ -4598,12 +4600,30 @@ async def test_execute_sql_query_keyset_rejects_when_global_row_budget_exceeded(
                 page_size=30,
             )
         )
+        assert "error" not in page_two
+        assert len(page_two["rows"]) == 20
+        assert page_two["metadata"]["page_size"] == 20
+        assert page_two["metadata"]["pagination.keyset.effective_page_size"] == 20
+        assert page_two["metadata"]["pagination.keyset.page_size_effective"] == 20
+        cursor_two = page_two["metadata"]["next_keyset_cursor"]
+        assert cursor_two
 
-    assert page_two["error"]["category"] == "invalid_request"
+        page_three = json.loads(
+            await handler(
+                sql,
+                tenant_id=1,
+                pagination_mode="keyset",
+                keyset_cursor=cursor_two,
+                page_size=30,
+            )
+        )
+
+    assert page_three["error"]["category"] == "invalid_request"
     assert (
-        page_two["error"]["details_safe"]["reason_code"] == "PAGINATION_GLOBAL_ROW_BUDGET_EXCEEDED"
+        page_three["error"]["details_safe"]["reason_code"]
+        == "PAGINATION_GLOBAL_ROW_BUDGET_EXCEEDED"
     )
-    metadata = page_two["metadata"]
+    metadata = page_three["metadata"]
     assert metadata["pagination.budget.exhausted"] is True
     assert metadata["pagination.budget.reason_code"] == "PAGINATION_GLOBAL_ROW_BUDGET_EXCEEDED"
     assert metadata["pagination.budget.rows_remaining_bucket"] in {
@@ -4700,6 +4720,9 @@ async def test_execute_sql_query_keyset_boundary_continuation_rejected_after_exa
             )
         )
         assert "error" not in page_two
+        assert len(page_two["rows"]) == 40
+        assert page_two["metadata"]["page_size"] == 40
+        assert page_two["metadata"]["pagination.keyset.page_size_effective"] == 40
         assert page_two["metadata"]["pagination.budget.exhausted"] is True
         cursor_two = page_two["metadata"]["next_keyset_cursor"]
         assert cursor_two
@@ -4723,8 +4746,10 @@ async def test_execute_sql_query_keyset_boundary_continuation_rejected_after_exa
 
 
 @pytest.mark.asyncio
-async def test_execute_sql_query_keyset_rejects_when_global_byte_budget_exceeded(monkeypatch):
-    """Second page should fail closed when cumulative bytes exceed request budget."""
+async def test_execute_sql_query_keyset_rejects_when_no_safe_page_size_can_be_served(
+    monkeypatch,
+):
+    """Continuation should fail closed when remaining byte budget cannot safely fit one row."""
     caps = SimpleNamespace(
         provider_name="postgres",
         tenant_enforcement_mode="rls_session",
@@ -4783,7 +4808,11 @@ async def test_execute_sql_query_keyset_rejects_when_global_byte_budget_exceeded
 
     assert page_two["error"]["category"] == "invalid_request"
     assert (
-        page_two["error"]["details_safe"]["reason_code"] == "PAGINATION_GLOBAL_BYTE_BUDGET_EXCEEDED"
+        page_two["error"]["details_safe"]["reason_code"] == "PAGINATION_SESSION_NO_SAFE_PAGE_SIZE"
+    )
+    assert (
+        page_two["metadata"]["pagination.budget.reason_code"]
+        == "PAGINATION_SESSION_NO_SAFE_PAGE_SIZE"
     )
 
 


### PR DESCRIPTION
This PR adds adaptive page sizing for pagination session continuations across offset and keyset modes. Instead of immediately rejecting a continuation when the originally requested page size would exceed the remaining session budget, the system now computes the largest safe effective page size from remaining row and byte budgets and serves that page when possible. The implementation preserves existing session validation and budget accounting semantics, adds bounded telemetry and envelope parity for adaptive sizing decisions, and includes classification parity and multi-page regression tests to prevent drift across enforcement surfaces.

Closes #805